### PR TITLE
Harden master crop steering app: safe logging, config normalization, safety sweep & watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,18 @@ The Home Assistant integration creates entities and fires events, but **AppDaemo
 - Performs calculations (shot durations, EC ratio, adjusted thresholds)
 - Fires events that AppDaemon listens to
 
+> **Important integration note:** This repository currently uses a custom integration
+> service/event handshake as the primary GUI↔automation contract. Home Assistant
+> Blueprints are not required for core operation in the current architecture.
+
 **AppDaemon Master App (optional but recommended for automation):**
 - Listens to sensor updates and integration events
 - Makes irrigation decisions based on phase logic and thresholds
 - Sequences hardware safely to prevent damage
 - Manages phase transitions automatically
 - Validates sensor data and detects anomalies
+- Publishes runtime status (`sensor.crop_steering_app_status`) and enforces
+  watchdog fail-safes to force hardware OFF on desync/error conditions
 
 **Configuration sources:**
 - Primary: Integration UI during setup (maps hardware and sensors)

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -11,6 +11,22 @@ master_crop_steering:
   class: MasterCropSteeringApp
   log: crop_steering_master
   log_level: INFO
+  # Optional explicit config. Safe defaults exist in code, but defining these
+  # keys avoids schema ambiguity and documents expected AppDaemon args.
+  hardware:
+    pump_master: null
+    main_line: null
+    zone_valves: {}
+  sensors:
+    vwc: []
+    ec: []
+    environmental: {}
+  timing:
+    phase_check_interval: 60
+    ml_prediction_interval: 300
+    sensor_health_interval: 120
+  thresholds:
+    emergency_vwc: 40.0
 
 # Advanced Dashboard Application  
 # Provides real-time Athena-style monitoring and analytics

--- a/docs/remediation_tasklist.md
+++ b/docs/remediation_tasklist.md
@@ -1,0 +1,50 @@
+# Crop Steering Remediation Task List (Phase 1-5)
+
+This checklist tracks the production-hardening work performed for the AppDaemon + Home Assistant Crop Steering stack.
+
+## ✅ Phase 1 — Stack & Dependency Audit
+
+- [x] Verified AppDaemon `apps.yaml` handshake and added explicit optional config blocks (`hardware`, `sensors`, `timing`, `thresholds`).
+- [x] Normalized legacy hardware key compatibility (`zone_switches` -> `zone_valves`).
+- [x] Added robust zone valve key normalization for int/string key mismatches.
+- [x] Audited integration event handshake (`crop_steering_*` events) and aligned runtime listeners.
+
+## ✅ Phase 2 — Code Review & QA Hardening
+
+- [x] Added startup safety sweep to force irrigation hardware OFF on restart.
+- [x] Added serialized irrigation execution lock to prevent concurrent run collisions.
+- [x] Added explicit preflight conflict checks before irrigation execution.
+- [x] Added guaranteed best-effort shutdown in irrigation `finally` cleanup.
+- [x] Added runtime watchdog for software/hardware desynchronization detection.
+- [x] Added fail-safe emergency stop when all configured VWC sensors are offline while hardware is active.
+- [x] Fixed `set_entity_value` usage bugs (`state=` misuse) in runtime sensor publishing paths.
+
+## ✅ Phase 3 — Gap Analysis / Contract Clarity
+
+- [x] Clarified architecture contract in docs: this repo currently uses custom integration service/event handshake as primary GUI/backend bridge.
+- [x] Consolidated zone sensor matching logic into one helper for consistent VWC/EC zone selection.
+
+## ✅ Phase 4 — Remediation Plan Outcomes
+
+- [x] Safety-first watchdog and status telemetry implemented.
+- [x] Config simplification and normalization completed in runtime loader.
+- [x] Additional config sanitation added (non-string/empty sensor IDs filtered before use).
+
+## ✅ Phase 5 — Execution
+
+- [x] Refactored major risk areas in `master_crop_steering_app.py` for modular helpers and safety boundaries.
+- [x] Added runtime status telemetry entity (`sensor.crop_steering_app_status`) for dashboard observability.
+- [x] Added robust logging around safety events and watchdog actions.
+
+## 🔍 Remaining (Live Environment Validation)
+
+These require an actual Home Assistant + AppDaemon runtime and cannot be fully validated in this CI shell:
+
+- [ ] Validate full irrigation cycle in live HA (P0/P1/P2/P3 transitions).
+- [ ] Verify hardware sequencing against real valves/pump entities.
+- [ ] Confirm dashboard visibility for status and safety sensors.
+- [ ] Run a controlled sensor-outage simulation and verify emergency-stop behavior.
+
+## Deployment Note
+
+Use the generated pull requests from this branch to merge changes to GitHub, then deploy to your HA/AppDaemon instance and run the live checks above.


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and unreliable behavior caused by unsafe formatting of `None` VWC values in frequently executed logs and fragile assumptions about config shape.
- Improve production safety by ensuring irrigation hardware is never left in an unknown state after restart or during software/hardware desyncs.
- Normalize and sanitize configuration inputs to avoid KeyErrors and silent misconfiguration when older/partial `apps.yaml` entries exist.
- Increase robustness of irrigation execution to prevent concurrent runs and guarantee best-effort hardware shutdown on errors.

### Description
- Guarded string formatting for VWC/related logs to use `N/A` when values are `None` to avoid `:.1f` formatting exceptions in several logging sites.
- Added configuration defaults and normalization via `_get_default_config` and merged/cleaned `self.args` to ensure `hardware`, `sensors`, `timing`, and `thresholds` keys exist and are sanitized.
- Introduced startup safety sweep (`_startup_safety_sweep`) to force an emergency stop on restart and a runtime status publisher (`_publish_status`) with deduplication to reduce churn.
- Made irrigation execution robust: added an asyncio lock for serialized irrigation, preflight conflict and safety checks, robust entity key handling (`_get_zone_valve_entity`), full turn-on/turn-off sequencing with `finally` cleanup, and improved result reporting.
- Implemented sensor/zone helper `_sensor_matches_zone` for reliable sensor-to-zone matching and updated many VWC/EC selection paths to use it.
- Added a periodic watchdog (`_watchdog_check`) and sensor-health fail-safe to automatically stop hardware on desyncs or when all VWC sensors are offline while hardware is active.
- Minor app configuration and docs changes: expanded `apps.yaml` optional config block, README clarifications, and added `docs/remediation_tasklist.md` describing the hardening work.

### Testing
- Compiled the modified module with `python -m py_compile appdaemon/apps/crop_steering/master_crop_steering_app.py`, which completed successfully. 
- No unit tests were available in this environment; changes were validated via static compilation and targeted runtime-safety checks in code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698afcc98cd08323b548bb56b3994789)