### PR TITLE
Remove GW/Green Wave branding — restore generic Irrigation naming

### DIFF
--- a/SYSTEM_GUIDE.html
+++ b/SYSTEM_GUIDE.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>GreenWave + Crop Steering — Complete System Guide</title>
+<title>Irrigation + Crop Steering — Complete System Guide</title>
 <style>
   :root{--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--muted:#8b949e;--blue:#58a6ff;--green:#3fb950;--orange:#d29922;--red:#f85149;--purple:#bc8cff;--code-bg:#1c2128;--stripe:#1c2128}
   *{box-sizing:border-box;margin:0;padding:0}html{scroll-behavior:smooth}
@@ -27,7 +27,7 @@
   .cycle{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1.1rem;text-align:center;font-family:'SF Mono',monospace;font-size:.93rem;margin:1.3rem 0;overflow-x:auto;white-space:nowrap}
   .top-btn{position:fixed;bottom:1.5rem;right:1.5rem;background:var(--blue);color:var(--bg);width:38px;height:38px;border-radius:50%;display:flex;align-items:center;justify-content:center;text-decoration:none;font-weight:700;font-size:1.1rem;box-shadow:0 2px 8px rgba(0,0,0,.4);opacity:.8}.top-btn:hover{opacity:1;text-decoration:none}
   .print-btn{position:fixed;bottom:1.5rem;right:4.5rem;background:var(--green);color:var(--bg);border:none;padding:8px 16px;border-radius:6px;cursor:pointer;font-size:.85rem;font-weight:600;box-shadow:0 2px 8px rgba(0,0,0,.4)}.print-btn:hover{background:#4fcc60}
-  .tag{display:inline-block;font-size:.65rem;font-weight:700;padding:1px 6px;border-radius:3px;margin-left:5px;vertical-align:middle}.tag-gw{background:#1a3a2a;color:var(--green);border:1px solid var(--green)}.tag-cs{background:#0d1f3c;color:var(--blue);border:1px solid var(--blue)}.tag-both{background:#2a1a2a;color:var(--purple);border:1px solid var(--purple)}
+  .tag{display:inline-block;font-size:.65rem;font-weight:700;padding:1px 6px;border-radius:3px;margin-left:5px;vertical-align:middle}.tag-irrigation{background:#1a3a2a;color:var(--green);border:1px solid var(--green)}.tag-cs{background:#0d1f3c;color:var(--blue);border:1px solid var(--blue)}.tag-both{background:#2a1a2a;color:var(--purple);border:1px solid var(--purple)}
   @media print{body{background:#fff;color:#000;max-width:100%;padding:.5cm;font-size:10pt;line-height:1.35}h1{color:#000;border-bottom-color:#000;font-size:18pt}h2{color:#222;font-size:13pt;break-after:avoid}h3{color:#333;font-size:11pt;break-after:avoid}.sub{color:#666}a{color:#000}code{background:#f0f0f0;color:#333;border:1px solid #ddd}pre{background:#f8f8f8;border-color:#ccc}pre code{color:#000;border:none}th{background:#e8e8e8;color:#000}td{border-color:#ccc}tr:nth-child(even) td{background:#f5f5f5}tr:hover td{background:#f5f5f5}.toc{background:#f8f8f8;border-color:#ccc;break-inside:avoid}.toc a{color:#333}.phase{background:#f8f8f8}.box{border-width:1px}.warn{background:#fff8e1;border-color:#f9a825}.danger{background:#ffebee;border-color:#e53935}.info{background:#e3f2fd;border-color:#1976d2}.ok{background:#e8f5e9;border-color:#4caf50}.unmapped{background:#f3e5f5;border-color:#9c27b0}.cycle{background:#f8f8f8;border-color:#ccc}.top-btn,.print-btn{display:none}.tag{border:1px solid #999;color:#333;background:#eee}table{break-inside:auto;font-size:9pt}tr{break-inside:avoid}@page{size:A4;margin:12mm}}
   @media(max-width:768px){body{padding:1rem}h1{font-size:1.5rem}.toc{columns:1}table{font-size:.8rem}td,th{padding:.3rem .45rem}}
 </style>
@@ -36,7 +36,7 @@
 <button class="print-btn" onclick="window.print()">Print</button>
 <a href="#top" class="top-btn" title="Top">&uarr;</a>
 
-<h1>GreenWave + Crop Steering System Guide</h1>
+<h1>Irrigation + Crop Steering System Guide</h1>
 <p class="sub">Version 2.3.1 &nbsp;|&nbsp; 6-Zone Coco Coir &nbsp;|&nbsp; Athena Nutrients &nbsp;|&nbsp; GroundWork Probes &nbsp;|&nbsp; April 2026</p>
 
 <nav class="toc"><h2>Contents</h2>
@@ -46,7 +46,7 @@
 <li><a href="#s3">Architecture &amp; Data Flow</a></li>
 <li><a href="#s4">The Four Phases (P0&ndash;P3)</a></li>
 <li><a href="#s5">Daily Cycle</a></li>
-<li><a href="#s6">GW Time-Based Scheduler</a></li>
+<li><a href="#s6">Irrigation Time-Based Scheduler</a></li>
 <li><a href="#s7">Environment Control</a></li>
 <li><a href="#s8">Entity Reference</a></li>
 <li><a href="#s9">Configuration Files</a></li>
@@ -70,50 +70,50 @@
 
 <h2 id="s1">1. System Overview</h2>
 <p>This system automates irrigation and climate control for a 6-table cannabis grow room running coco coir with Athena nutrients and GroundWork substrate probes. Two layers run simultaneously:</p>
-<div class="box ok"><h4>GreenWave Package <span class="tag tag-gw">GW</span></h4><p>Time-based irrigation scheduler (should be OFF when crop steering is active), environment control (CO2, dehumidifiers, humidifier), and safety watchdogs. Runs in HA via YAML packages at <code>/config/packages/green_wave/</code>.</p></div>
+<div class="box ok"><h4>Irrigation Package <span class="tag tag-irrigation">Irrigation</span></h4><p>Time-based irrigation scheduler (should be OFF when crop steering is active), environment control (CO2, dehumidifiers, humidifier), and safety watchdogs. Runs in HA via YAML packages at <code>/config/packages/irrigation/</code>.</p></div>
 <div class="box info"><h4>Crop Steering AI <span class="tag tag-cs">CS</span></h4><p>Sensor-driven 4-phase irrigation (P0&ndash;P3) with per-zone control, EC ratio logic, ML prediction, dryback detection, and emergency management. Runs as AppDaemon app + HA custom component. <strong>This is the active irrigation brain.</strong></p></div>
-<div class="box warn"><strong>To prevent double-watering:</strong> Set <code>input_boolean.gw_irrigation_enabled</code> to OFF when crop steering is handling irrigation. GW environment controls remain active independently.</div>
+<div class="box warn"><strong>To prevent double-watering:</strong> Set <code>input_boolean.irrigation_irrigation_enabled</code> to OFF when crop steering is handling irrigation. Irrigation environment controls remain active independently.</div>
 
 <hr>
 <h2 id="s2">2. Hardware Map</h2>
 <h3>Irrigation</h3>
 <table>
-<tr><th>Component</th><th>GW Entity</th><th>Raw Entity</th><th>Physical</th></tr>
-<tr><td>Main Line</td><td><code>switch.gw_mainline</code></td><td><code>switch.mainline</code></td><td>Mainline solenoid (KC868)</td></tr>
-<tr><td>Zone 1&ndash;6 Valves</td><td><code>switch.gw_table_N_valve</code></td><td><code>switch.table_N</code></td><td>Table solenoids (KC868)</td></tr>
+<tr><th>Component</th><th>Irrigation Entity</th><th>Raw Entity</th><th>Physical</th></tr>
+<tr><td>Main Line</td><td><code>switch.irrigation_mainline</code></td><td><code>switch.mainline</code></td><td>Mainline solenoid (KC868)</td></tr>
+<tr><td>Zone 1&ndash;6 Valves</td><td><code>switch.irrigation_table_N_valve</code></td><td><code>switch.table_N</code></td><td>Table solenoids (KC868)</td></tr>
 <tr><td>Pump</td><td colspan="2">None &mdash; auto-start</td><td>Constant pressure switch</td></tr>
-<tr><td>Mains Water</td><td><code>switch.gw_mains_water</code></td><td><code>switch.mains_water</code></td><td>Tank fill only (NOT irrigation)</td></tr>
-<tr><td>Manifold</td><td><code>switch.gw_manifold</code></td><td><code>switch.manifold</code></td><td>Tank mixing only (NOT irrigation)</td></tr>
+<tr><td>Mains Water</td><td><code>switch.irrigation_mains_water</code></td><td><code>switch.mains_water</code></td><td>Tank fill only (NOT irrigation)</td></tr>
+<tr><td>Manifold</td><td><code>switch.irrigation_manifold</code></td><td><code>switch.manifold</code></td><td>Tank mixing only (NOT irrigation)</td></tr>
 </table>
 <h3>Sensors (1 probe per zone)</h3>
 <table>
 <tr><th>Zone</th><th>VWC</th><th>EC</th></tr>
 <tr><td>1&ndash;6</td><td><code>sensor.substrate_N_substrate_N_vwc_coco_coir</code></td><td><code>sensor.substrate_N_substrate_N_pwec</code></td></tr>
 </table>
-<p>GW mapping layer creates aliases: <code>sensor.gw_table_N_vwc</code> / <code>_ec</code> / <code>_substrate_temp</code>. Crop steering reads the raw entities directly.</p>
+<p>Irrigation mapping layer creates aliases: <code>sensor.irrigation_table_N_vwc</code> / <code>_ec</code> / <code>_substrate_temp</code>. Crop steering reads the raw entities directly.</p>
 <h3>Environment</h3>
 <table>
 <tr><th>Sensor</th><th>Entity</th><th>Source</th></tr>
-<tr><td>Room temp</td><td><code>sensor.gw_room_1_temp</code></td><td>Avg of 4 calibrated sensors</td></tr>
-<tr><td>Room RH</td><td><code>sensor.gw_room_1_rh</code></td><td>Avg of 4 sensors</td></tr>
-<tr><td>Room CO2</td><td><code>sensor.gw_room_1_co2</code></td><td>Avg of 3&ndash;4 CO2 sensors</td></tr>
-<tr><td>Room VPD</td><td><code>sensor.gw_room_1_vpd</code></td><td>Avg from CO2 sensors</td></tr>
+<tr><td>Room temp</td><td><code>sensor.irrigation_room_1_temp</code></td><td>Avg of 4 calibrated sensors</td></tr>
+<tr><td>Room RH</td><td><code>sensor.irrigation_room_1_rh</code></td><td>Avg of 4 sensors</td></tr>
+<tr><td>Room CO2</td><td><code>sensor.irrigation_room_1_co2</code></td><td>Avg of 3&ndash;4 CO2 sensors</td></tr>
+<tr><td>Room VPD</td><td><code>sensor.irrigation_room_1_vpd</code></td><td>Avg from CO2 sensors</td></tr>
 </table>
 <table>
 <tr><th>Device</th><th>Entity</th><th>Notes</th></tr>
-<tr><td>CO2 solenoid</td><td><code>switch.gw_co2</code></td><td>Solid state relay</td></tr>
-<tr><td>Humidifier</td><td><code>switch.gw_humidifier</code></td><td>Solid state relay</td></tr>
-<tr><td>Dehumidifier (plug)</td><td><code>switch.gw_dehumidifier_1</code></td><td>TP-Link Kasa WiFi plug</td></tr>
-<tr><td>Dehumidifier relays 1&ndash;4</td><td><code>switch.gw_dehumidifier_relay_1</code>&ndash;<code>4</code></td><td>Staggered 10s apart</td></tr>
+<tr><td>CO2 solenoid</td><td><code>switch.irrigation_co2</code></td><td>Solid state relay</td></tr>
+<tr><td>Humidifier</td><td><code>switch.irrigation_humidifier</code></td><td>Solid state relay</td></tr>
+<tr><td>Dehumidifier (plug)</td><td><code>switch.irrigation_dehumidifier_1</code></td><td>TP-Link Kasa WiFi plug</td></tr>
+<tr><td>Dehumidifier relays 1&ndash;4</td><td><code>switch.irrigation_dehumidifier_relay_1</code>&ndash;<code>4</code></td><td>Staggered 10s apart</td></tr>
 <tr><td>AC 1&ndash;4</td><td><code>climate.ac_*</code></td><td>IR via ESPHome. <strong>Mapped, NOT automated.</strong></td></tr>
 <tr><td>Lights</td><td><code>light.grow_room_all_lights</code></td><td>ESPHome group</td></tr>
 </table>
 <div class="box unmapped"><strong>Unmapped / not installed:</strong>
 <ul>
-<li><code>binary_sensor.gw_leak</code> &mdash; <strong>hardcoded false</strong>. Leak abort won't fire.</li>
-<li><code>binary_sensor.gw_tank_low</code> &mdash; <strong>hardcoded false</strong>. Tank-low abort won't fire.</li>
+<li><code>binary_sensor.irrigation_leak</code> &mdash; <strong>hardcoded false</strong>. Leak abort won't fire.</li>
+<li><code>binary_sensor.irrigation_tank_low</code> &mdash; <strong>hardcoded false</strong>. Tank-low abort won't fire.</li>
 <li>Tank pH/EC probes &mdash; unavailable</li>
-<li><code>switch.gw_waste_valve</code>, <code>switch.gw_ceiling_vent</code> &mdash; TODO placeholders</li>
+<li><code>switch.irrigation_waste_valve</code>, <code>switch.irrigation_ceiling_vent</code> &mdash; TODO placeholders</li>
 <li>AC control automations &mdash; entities mapped, no logic</li>
 </ul></div>
 
@@ -123,7 +123,7 @@
     |
 Raw entities (sensor.substrate_N_substrate_N_vwc_coco_coir)
     |   [10_mapping.yaml]
-GW contract entities (sensor.gw_table_N_vwc)
+Irrigation contract entities (sensor.irrigation_table_N_vwc)
     |
     +-- crop_steering.env
     |
@@ -135,11 +135,11 @@ AppDaemon master app (listen_state + REST API fallback)
     |
 Hardware (valve switches via HA services)</code></pre>
 <div class="box warn"><strong>Entity naming:</strong> Custom component entities have <code>crop_steering_</code> prefix (e.g. <code>switch.crop_steering_system_enabled</code>). AppDaemon tries both prefixed and unprefixed names. Sensors created by AppDaemon use exact IDs shown.</div>
-<h3>GW Package Files</h3>
+<h3>Irrigation Package Files</h3>
 <table>
 <tr><th>File</th><th>Purpose</th></tr>
 <tr><td><code>00_core.yaml</code></td><td>Emergency stop script, alert helper</td></tr>
-<tr><td><code>10_mapping.yaml</code></td><td>Raw ESPHome &rarr; <code>gw_*</code> contract aliases</td></tr>
+<tr><td><code>10_mapping.yaml</code></td><td>Raw ESPHome &rarr; <code>irrigation_*</code> contract aliases</td></tr>
 <tr><td><code>20_model.yaml</code></td><td>Input helpers (schedules, targets, timers)</td></tr>
 <tr><td><code>30_irrigation.yaml</code></td><td>Time-based scheduler + abort automations</td></tr>
 <tr><td><code>40_environment.yaml</code></td><td>Dehumidifier, humidifier, CO2 automations</td></tr>
@@ -181,20 +181,20 @@ Hardware (valve switches via HA services)</code></pre>
 <p>Max 1 concurrent zone. <code>finally</code> block ensures hardware off on error.</p>
 
 <hr>
-<h2 id="s6">6. GW Time-Based Scheduler <span class="tag tag-gw">GW</span></h2>
-<div class="box warn"><strong>Must be OFF when crop steering is active.</strong> Set <code>input_boolean.gw_irrigation_enabled</code> to OFF.</div>
+<h2 id="s6">6. Irrigation Time-Based Scheduler <span class="tag tag-irrigation">Irrigation</span></h2>
+<div class="box warn"><strong>Must be OFF when crop steering is active.</strong> Set <code>input_boolean.irrigation_irrigation_enabled</code> to OFF.</div>
 <p>Checks every 5 min: system enabled, irrigation enabled, not maintenance, no leak, no tank low, within time window, interval elapsed. Opens mainline, runs each enabled table for configured duration sequentially, closes mainline.</p>
 <table>
 <tr><th>Setting</th><th>Entity</th><th>Default</th></tr>
-<tr><td>Window start/end</td><td><code>input_datetime.gw_irrigate_start/end_time</code></td><td>Set in HA</td></tr>
-<tr><td>Interval</td><td><code>input_number.gw_irrigate_interval_min</code></td><td>60 min</td></tr>
-<tr><td>Duration</td><td><code>input_number.gw_irrigate_duration_sec</code></td><td>60s</td></tr>
-<tr><td>Table N</td><td><code>input_boolean.gw_table_N_enabled</code></td><td>OFF</td></tr>
+<tr><td>Window start/end</td><td><code>input_datetime.irrigation_irrigate_start/end_time</code></td><td>Set in HA</td></tr>
+<tr><td>Interval</td><td><code>input_number.irrigation_irrigate_interval_min</code></td><td>60 min</td></tr>
+<tr><td>Duration</td><td><code>input_number.irrigation_irrigate_duration_sec</code></td><td>60s</td></tr>
+<tr><td>Table N</td><td><code>input_boolean.irrigation_table_N_enabled</code></td><td>OFF</td></tr>
 </table>
 
 <hr>
-<h2 id="s7">7. Environment Control <span class="tag tag-gw">GW</span></h2>
-<p>Gated by <code>input_boolean.gw_environment_enabled</code>.</p>
+<h2 id="s7">7. Environment Control <span class="tag tag-irrigation">Irrigation</span></h2>
+<p>Gated by <code>input_boolean.irrigation_environment_enabled</code>.</p>
 <h3>Dehumidifiers</h3>
 <p>4 relays stagger ON 10s apart. <strong>ON:</strong> RH &gt; target + 5% for 3 min. <strong>OFF:</strong> RH &lt; target &minus; 2% for 2 min. TP-Link plug has separate UI automations at 75%/65%.</p>
 <h3>Humidifier</h3>
@@ -205,9 +205,9 @@ Hardware (valve switches via HA services)</code></pre>
 <p>4 units mapped. <strong>No automated control yet</strong> &mdash; manual or separate automations.</p>
 <table>
 <tr><th>Target</th><th>Entity</th></tr>
-<tr><td>Day/Night temp</td><td><code>input_number.gw_temp_target_day/night</code></td></tr>
-<tr><td>Day/Night RH</td><td><code>input_number.gw_rh_target_day/night</code></td></tr>
-<tr><td>CO2</td><td><code>input_number.gw_co2_target</code></td></tr>
+<tr><td>Day/Night temp</td><td><code>input_number.irrigation_temp_target_day/night</code></td></tr>
+<tr><td>Day/Night RH</td><td><code>input_number.irrigation_rh_target_day/night</code></td></tr>
+<tr><td>CO2</td><td><code>input_number.irrigation_co2_target</code></td></tr>
 </table>
 
 <hr>
@@ -267,14 +267,14 @@ Hardware (valve switches via HA services)</code></pre>
 <tr><td><code>sensor.crop_steering_fused_vwc</code> / <code>_ec</code></td><td>Kalman-filtered averages</td></tr>
 <tr><td><code>sensor.crop_steering_system_health_score</code></td><td>0&ndash;100 health</td></tr>
 </table>
-<h3>GW Helpers</h3>
+<h3>Irrigation Helpers</h3>
 <table>
 <tr><th>Entity</th><th>Purpose</th></tr>
-<tr><td><code>input_boolean.gw_enable</code></td><td>GW master</td></tr>
-<tr><td><code>input_boolean.gw_irrigation_enabled</code></td><td>GW scheduler (OFF when CS active)</td></tr>
-<tr><td><code>input_boolean.gw_maintenance_mode</code></td><td>Emergency close all</td></tr>
-<tr><td><code>input_boolean.gw_co2_enabled</code></td><td>CO2 on/off</td></tr>
-<tr><td><code>input_boolean.gw_environment_enabled</code></td><td>Climate on/off</td></tr>
+<tr><td><code>input_boolean.irrigation_enable</code></td><td>Irrigation master</td></tr>
+<tr><td><code>input_boolean.irrigation_irrigation_enabled</code></td><td>Irrigation scheduler (OFF when CS active)</td></tr>
+<tr><td><code>input_boolean.irrigation_maintenance_mode</code></td><td>Emergency close all</td></tr>
+<tr><td><code>input_boolean.irrigation_co2_enabled</code></td><td>CO2 on/off</td></tr>
+<tr><td><code>input_boolean.irrigation_environment_enabled</code></td><td>Climate on/off</td></tr>
 </table>
 <h3>Events</h3>
 <table>
@@ -287,7 +287,7 @@ Hardware (valve switches via HA services)</code></pre>
 <hr>
 <h2 id="s9">9. Configuration Files</h2>
 <h3>crop_steering.env</h3>
-<pre><code>ZONE_1_SWITCH=switch.gw_table_1_valve
+<pre><code>ZONE_1_SWITCH=switch.irrigation_table_1_valve
 ZONE_1_VWC_SENSORS=sensor.substrate_1_substrate_1_vwc_coco_coir
 ZONE_1_EC_SENSORS=sensor.substrate_1_substrate_1_pwec
 ZONE_1_PLANT_COUNT=4
@@ -299,8 +299,8 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
   class: MasterCropSteeringApp
   hardware:
     pump_master: null
-    main_line: switch.gw_mainline
-    zone_valves: {1: switch.gw_table_1_valve, ...}
+    main_line: switch.irrigation_mainline
+    zone_valves: {1: switch.irrigation_table_1_valve, ...}
   timing: {phase_check_interval: 60}
   thresholds: {emergency_vwc: 40.0}</code></pre>
 <p><strong>Lights:</strong> <code>lights_on_hour</code> = 8, <code>lights_off_hour</code> = 20.</p>
@@ -309,7 +309,7 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <h2 id="s10">10. Dashboards</h2>
 <table>
 <tr><th>Dashboard</th><th>Path</th><th>Purpose</th></tr>
-<tr><td>GW Irrigation</td><td><code>gw-irrigation</code></td><td>Timer scheduler, table enables, hardware, safety</td></tr>
+<tr><td>Irrigation</td><td><code>irrigation</code></td><td>Timer scheduler, table enables, hardware, safety</td></tr>
 <tr><td>Crop Steering AI</td><td><code>crop-steering</code></td><td>Phases, VWC/EC, zone tuning, AI oversight, all parameters</td></tr>
 <tr><td>CO2 &amp; Environment</td><td><code>co2-environment</code></td><td>CO2, dehumidifier, temp/RH targets</td></tr>
 </table>
@@ -408,7 +408,7 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <h3>Crop Steering (per shot)</h3>
 <ol><li>System enabled</li><li>Auto irrigation (auto only)</li><li>Zone enabled</li><li>Override OFF</li><li>Tank not filling</li><li>VWC &lt; field capacity (80%)</li><li>EC &lt; max (9.0)</li><li>Daily volume &lt; 20L</li><li>VWC &lt; 90%</li><li>EC &lt; 15.0</li><li>&gt;10 min since last</li><li>&lt;50 shots/day</li><li>Phase-specific</li><li>Max 1 concurrent zone</li><li>Async lock</li></ol>
 <p>Watchdog (60s): flag/hardware mismatch detection. Sensor fail-safe: all offline + hardware on &rarr; stop. Clean shutdown on terminate.</p>
-<h3>GW Safety</h3>
+<h3>Irrigation Safety</h3>
 <table>
 <tr><th>Protection</th><th>What</th></tr>
 <tr><td>Valve watchdog</td><td>Open &gt;180s &rarr; force close + alert</td></tr>
@@ -452,17 +452,17 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <h2 id="s22">22. Commissioning</h2>
 <h3>1. Verify Hardware</h3>
 <ol><li>ESPHome devices online: <strong>Settings &rarr; Devices &rarr; ESPHome</strong></li>
-<li><code>sensor.gw_table_1_vwc</code> shows number. Check all 6.</li>
+<li><code>sensor.irrigation_table_1_vwc</code> shows number. Check all 6.</li>
 <li>Test each valve via Developer Tools. Listen for click. Off immediately.</li>
 <li>Test mainline briefly &mdash; pump should start.</li></ol>
 <h3>2. Configure Crop Steering</h3>
 <ol><li>Verify <code>crop_steering.env</code> entity IDs</li>
 <li>Add integration: Settings &rarr; Integrations &rarr; Crop Steering &rarr; Load from .env</li>
 <li>Set lights_on=8, lights_off=20</li>
-<li><strong>Set <code>gw_irrigation_enabled</code> OFF</strong></li></ol>
+<li><strong>Set <code>irrigation_irrigation_enabled</code> OFF</strong></li></ol>
 <h3>3. Environment</h3>
 <ol><li>Set temp/RH/CO2 targets on CO2 &amp; Environment dashboard</li>
-<li>Enable <code>gw_co2_enabled</code> and <code>gw_environment_enabled</code></li></ol>
+<li>Enable <code>irrigation_co2_enabled</code> and <code>irrigation_environment_enabled</code></li></ol>
 <h3>4. Start</h3>
 <ol><li><code>crop_steering_system_enabled</code> ON</li>
 <li>Check <code>app_status</code> = <code>safe_idle</code></li>
@@ -479,12 +479,12 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <tr><td>Phase changes ignored</td><td>Zone phase override must be "Auto".</td></tr>
 <tr><td>"Entity not found"</td><td>Entities have <code>crop_steering_</code> prefix.</td></tr>
 <tr><td>VWC "Unavailable"</td><td>ESPHome device offline. Check network.</td></tr>
-<tr><td>Double watering</td><td><code>gw_irrigation_enabled</code> must be OFF.</td></tr>
-<tr><td>CO2 not injecting</td><td>Lights must be on + <code>gw_co2_enabled</code> ON.</td></tr>
-<tr><td>Valves stuck</td><td><code>gw_maintenance_mode</code> ON, or <code>script.gw_emergency_stop</code>, or power off relay.</td></tr>
+<tr><td>Double watering</td><td><code>irrigation_irrigation_enabled</code> must be OFF.</td></tr>
+<tr><td>CO2 not injecting</td><td>Lights must be on + <code>irrigation_co2_enabled</code> ON.</td></tr>
+<tr><td>Valves stuck</td><td><code>irrigation_maintenance_mode</code> ON, or <code>script.irrigation_emergency_stop</code>, or power off relay.</td></tr>
 </table>
 <h3>Emergency Stop</h3>
-<ol><li><code>gw_maintenance_mode</code> ON</li><li><code>script.gw_emergency_stop</code></li><li><code>crop_steering_system_enabled</code> OFF</li><li>Power off relay board</li></ol>
+<ol><li><code>irrigation_maintenance_mode</code> ON</li><li><code>script.irrigation_emergency_stop</code></li><li><code>crop_steering_system_enabled</code> OFF</li><li>Power off relay board</li></ol>
 
 <hr>
 <h2 id="s24">24. Known Issues &amp; Unmapped Hardware</h2>
@@ -502,7 +502,7 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <li><strong>Entity prefix mismatch</strong> &mdash; CS entities have <code>crop_steering_</code> prefix. Dashboard/AppDaemon reference some without. Dual-naming fallback in place.</li>
 <li><strong>get_state() returns None</strong> for CS entities in AppDaemon. Workaround: listen_state + REST API.</li>
 <li><strong>P3 early transition</strong> with slow dryback rate. Self-corrects with data.</li>
-<li><strong>Duplicate dehumidifier automations</strong> &mdash; GW relays + UI TP-Link plug. Different hardware.</li>
+<li><strong>Duplicate dehumidifier automations</strong> &mdash; Irrigation relays + UI TP-Link plug. Different hardware.</li>
 <li><strong>Duplicate CO2 emergency</strong> &mdash; Both package and UI automation close at 1800 ppm.</li>
 </ul>
 <h3>Shot Reference</h3>
@@ -514,6 +514,6 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <p><strong>Notifications:</strong> <code>notify.mobile_app_damians_iphone</code>.</p>
 
 <hr>
-<p style="text-align:center;color:var(--muted);margin-top:2.5rem;font-size:.83rem">GreenWave + Crop Steering System Guide v2.3.1 &mdash; April 2026 &mdash; Verified from codebase audit</p>
+<p style="text-align:center;color:var(--muted);margin-top:2.5rem;font-size:.83rem">Irrigation + Crop Steering System Guide v2.3.1 &mdash; April 2026 &mdash; Verified from codebase audit</p>
 </body>
 </html>

--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -38,8 +38,8 @@ This is an automated irrigation controller for cannabis grown in coco coir. It r
 The system runs a 4-phase daily irrigation cycle (P0-P3) independently per zone. It uses sensor fusion, dryback detection, EC ratio logic, and an ML predictor to make irrigation decisions. Every decision passes through multiple safety checks before a valve opens.
 
 **Hardware controlled:**
-- 1 main line solenoid (`switch.gw_mainline`)
-- 6 zone valve solenoids (`switch.gw_table_1_valve` through `switch.gw_table_6_valve`)
+- 1 main line solenoid (`switch.irrigation_mainline`)
+- 6 zone valve solenoids (`switch.irrigation_table_1_valve` through `switch.irrigation_table_6_valve`)
 - No dedicated pump — constant-pressure switch auto-starts when the main line opens
 
 **Sensors read:**
@@ -103,7 +103,7 @@ The AppDaemon app tries both naming conventions (with and without prefix) when r
 
 Sensors **created by AppDaemon** (via `set_state`) do not have this issue — they use the exact entity ID passed (e.g., `sensor.crop_steering_zone_1_phase`).
 
-Hardware entities from other integrations keep their own naming (e.g., `switch.gw_mainline`, `sensor.substrate_1_substrate_1_vwc_coco_coir`).
+Hardware entities from other integrations keep their own naming (e.g., `switch.irrigation_mainline`, `sensor.substrate_1_substrate_1_vwc_coco_coir`).
 
 ### Communication Flow
 
@@ -219,8 +219,8 @@ The main decision loop runs every 60 seconds (`phase_check_interval`). Each cycl
 
 When a shot fires:
 
-1. Turn on main line (`switch.gw_mainline`), wait 1s
-2. Turn on zone valve (`switch.gw_table_N_valve`)
+1. Turn on main line (`switch.irrigation_mainline`), wait 1s
+2. Turn on zone valve (`switch.irrigation_table_N_valve`)
 3. Wait for shot duration
 4. Turn off zone valve, wait 1s
 5. Turn off main line, wait 1s
@@ -410,7 +410,7 @@ The primary configuration file. Located at `/config/crop_steering.env`. Parsed d
 
 **Zone definition (per zone):**
 ```
-ZONE_1_SWITCH=switch.gw_table_1_valve
+ZONE_1_SWITCH=switch.irrigation_table_1_valve
 ZONE_1_VWC_SENSORS=sensor.substrate_1_substrate_1_vwc_coco_coir
 ZONE_1_EC_SENSORS=sensor.substrate_1_substrate_1_pwec
 ZONE_1_PLANT_COUNT=4
@@ -443,10 +443,10 @@ master_crop_steering:
   class: MasterCropSteeringApp
   hardware:
     pump_master: null          # No pump — pressure switch auto-starts
-    main_line: switch.gw_mainline
+    main_line: switch.irrigation_mainline
     zone_valves:
-      1: switch.gw_table_1_valve
-      2: switch.gw_table_2_valve
+      1: switch.irrigation_table_1_valve
+      2: switch.irrigation_table_2_valve
       # ... through 6
   sensors:
     vwc:
@@ -456,9 +456,9 @@ master_crop_steering:
       - sensor.substrate_1_substrate_1_pwec
       # ... through 6
     environmental:
-      temperature: sensor.gw_room_1_temp
-      humidity: sensor.gw_room_1_rh
-      vpd: sensor.gw_room_1_vpd
+      temperature: sensor.irrigation_room_1_temp
+      humidity: sensor.irrigation_room_1_rh
+      vpd: sensor.irrigation_room_1_vpd
   timing:
     phase_check_interval: 60     # Decision loop interval (seconds)
     ml_prediction_interval: 300  # ML update interval (seconds)
@@ -961,13 +961,13 @@ The `_should_zone_start_p3()` calculation can trigger too early if the predicted
 
 | Component | Entity ID | Physical |
 |-----------|-----------|----------|
-| Main Line Valve | `switch.gw_mainline` | GroundWork mainline solenoid |
-| Zone 1 Valve | `switch.gw_table_1_valve` | Table 1 solenoid |
-| Zone 2 Valve | `switch.gw_table_2_valve` | Table 2 solenoid |
-| Zone 3 Valve | `switch.gw_table_3_valve` | Table 3 solenoid |
-| Zone 4 Valve | `switch.gw_table_4_valve` | Table 4 solenoid |
-| Zone 5 Valve | `switch.gw_table_5_valve` | Table 5 solenoid |
-| Zone 6 Valve | `switch.gw_table_6_valve` | Table 6 solenoid |
+| Main Line Valve | `switch.irrigation_mainline` | GroundWork mainline solenoid |
+| Zone 1 Valve | `switch.irrigation_table_1_valve` | Table 1 solenoid |
+| Zone 2 Valve | `switch.irrigation_table_2_valve` | Table 2 solenoid |
+| Zone 3 Valve | `switch.irrigation_table_3_valve` | Table 3 solenoid |
+| Zone 4 Valve | `switch.irrigation_table_4_valve` | Table 4 solenoid |
+| Zone 5 Valve | `switch.irrigation_table_5_valve` | Table 5 solenoid |
+| Zone 6 Valve | `switch.irrigation_table_6_valve` | Table 6 solenoid |
 | Pump | None (auto-start) | Constant pressure switch |
 | Zone 1 VWC | `sensor.substrate_1_substrate_1_vwc_coco_coir` | GroundWork substrate probe |
 | Zone 1 EC | `sensor.substrate_1_substrate_1_pwec` | GroundWork substrate probe (pore water EC) |
@@ -981,14 +981,14 @@ The `_should_zone_start_p3()` calculation can trigger too early if the predicted
 | Zone 5 EC | `sensor.substrate_5_substrate_5_pwec` | GroundWork substrate probe |
 | Zone 6 VWC | `sensor.substrate_6_substrate_6_vwc_coco_coir` | GroundWork substrate probe |
 | Zone 6 EC | `sensor.substrate_6_substrate_6_pwec` | GroundWork substrate probe |
-| Room Temp | `sensor.gw_room_1_temp` | GroundWork gateway sensor |
-| Room Humidity | `sensor.gw_room_1_rh` | GroundWork gateway sensor |
-| Room VPD | `sensor.gw_room_1_vpd` | GroundWork gateway sensor |
-| Mains Water | `switch.gw_mains_water` | Mains water valve (infrastructure) |
-| Manifold | `switch.gw_manifold` | Tank filling/mixing manifold |
-| Tank Fill | `switch.gw_tank_fill_valve` | Tank fill valve |
-| Waste Valve | `switch.gw_waste_valve` | Waste/drain valve |
-| Recirculation | `switch.gw_recirculation_valve` | Recirculation valve |
+| Room Temp | `sensor.irrigation_room_1_temp` | GroundWork gateway sensor |
+| Room Humidity | `sensor.irrigation_room_1_rh` | GroundWork gateway sensor |
+| Room VPD | `sensor.irrigation_room_1_vpd` | GroundWork gateway sensor |
+| Mains Water | `switch.irrigation_mains_water` | Mains water valve (infrastructure) |
+| Manifold | `switch.irrigation_manifold` | Tank filling/mixing manifold |
+| Tank Fill | `switch.irrigation_tank_fill_valve` | Tank fill valve |
+| Waste Valve | `switch.irrigation_waste_valve` | Waste/drain valve |
+| Recirculation | `switch.irrigation_recirculation_valve` | Recirculation valve |
 
 ### Irrigation Sequence Timing
 

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -15,14 +15,14 @@ master_crop_steering:
   # keys avoids schema ambiguity and documents expected AppDaemon args.
   hardware:
     pump_master: null  # No pump entity — constant pressure switch auto-starts when mainline opens
-    main_line: switch.gw_mainline
+    main_line: switch.irrigation_mainline
     zone_valves:
-      1: switch.gw_table_1_valve
-      2: switch.gw_table_2_valve
-      3: switch.gw_table_3_valve
-      4: switch.gw_table_4_valve
-      5: switch.gw_table_5_valve
-      6: switch.gw_table_6_valve
+      1: switch.irrigation_table_1_valve
+      2: switch.irrigation_table_2_valve
+      3: switch.irrigation_table_3_valve
+      4: switch.irrigation_table_4_valve
+      5: switch.irrigation_table_5_valve
+      6: switch.irrigation_table_6_valve
   sensors:
     vwc:
       - sensor.substrate_1_substrate_1_vwc_coco_coir
@@ -39,9 +39,9 @@ master_crop_steering:
       - sensor.substrate_5_substrate_5_pwec
       - sensor.substrate_6_substrate_6_pwec
     environmental:
-      temperature: sensor.gw_room_1_temp
-      humidity: sensor.gw_room_1_rh
-      vpd: sensor.gw_room_1_vpd
+      temperature: sensor.irrigation_room_1_temp
+      humidity: sensor.irrigation_room_1_rh
+      vpd: sensor.irrigation_room_1_vpd
   timing:
     phase_check_interval: 60
     ml_prediction_interval: 300

--- a/crop_steering.env
+++ b/crop_steering.env
@@ -1,7 +1,7 @@
 # ============================================================================
-# CROP STEERING — GREEN WAVE GROW PACK (growroom-site-01)
+# CROP STEERING — IRRIGATION GROW PACK (growroom-site-01)
 # ============================================================================
-# 6-table configuration using GW template entity wrappers.
+# 6-table configuration using Irrigation template entity wrappers.
 # Single substrate probe per table — uses VWC_SENSORS/EC_SENSORS (comma list).
 #
 # USAGE:
@@ -15,7 +15,7 @@
 # ============================================================================
 
 # --- TABLE 1 ---
-ZONE_1_SWITCH=switch.gw_table_1_valve
+ZONE_1_SWITCH=switch.irrigation_table_1_valve
 ZONE_1_VWC_SENSORS=sensor.substrate_1_substrate_1_vwc_coco_coir
 ZONE_1_EC_SENSORS=sensor.substrate_1_substrate_1_pwec
 ZONE_1_PLANT_COUNT=4
@@ -23,7 +23,7 @@ ZONE_1_MAX_DAILY_VOLUME=20.0
 ZONE_1_SHOT_MULTIPLIER=1.0
 
 # --- TABLE 2 ---
-ZONE_2_SWITCH=switch.gw_table_2_valve
+ZONE_2_SWITCH=switch.irrigation_table_2_valve
 ZONE_2_VWC_SENSORS=sensor.substrate_2_substrate_2_vwc_coco_coir
 ZONE_2_EC_SENSORS=sensor.substrate_2_substrate_2_pwec
 ZONE_2_PLANT_COUNT=4
@@ -31,7 +31,7 @@ ZONE_2_MAX_DAILY_VOLUME=20.0
 ZONE_2_SHOT_MULTIPLIER=1.0
 
 # --- TABLE 3 ---
-ZONE_3_SWITCH=switch.gw_table_3_valve
+ZONE_3_SWITCH=switch.irrigation_table_3_valve
 ZONE_3_VWC_SENSORS=sensor.substrate_3_substrate_3_vwc_coco_coir
 ZONE_3_EC_SENSORS=sensor.substrate_3_substrate_3_pwec
 ZONE_3_PLANT_COUNT=4
@@ -39,7 +39,7 @@ ZONE_3_MAX_DAILY_VOLUME=20.0
 ZONE_3_SHOT_MULTIPLIER=1.0
 
 # --- TABLE 4 ---
-ZONE_4_SWITCH=switch.gw_table_4_valve
+ZONE_4_SWITCH=switch.irrigation_table_4_valve
 ZONE_4_VWC_SENSORS=sensor.substrate_4_substrate_4_vwc_coco_coir
 ZONE_4_EC_SENSORS=sensor.substrate_4_substrate_4_pwec
 ZONE_4_PLANT_COUNT=4
@@ -47,7 +47,7 @@ ZONE_4_MAX_DAILY_VOLUME=20.0
 ZONE_4_SHOT_MULTIPLIER=1.0
 
 # --- TABLE 5 ---
-ZONE_5_SWITCH=switch.gw_table_5_valve
+ZONE_5_SWITCH=switch.irrigation_table_5_valve
 ZONE_5_VWC_SENSORS=sensor.substrate_5_substrate_5_vwc_coco_coir
 ZONE_5_EC_SENSORS=sensor.substrate_5_substrate_5_pwec
 ZONE_5_PLANT_COUNT=4
@@ -55,7 +55,7 @@ ZONE_5_MAX_DAILY_VOLUME=20.0
 ZONE_5_SHOT_MULTIPLIER=1.0
 
 # --- TABLE 6 ---
-ZONE_6_SWITCH=switch.gw_table_6_valve
+ZONE_6_SWITCH=switch.irrigation_table_6_valve
 ZONE_6_VWC_SENSORS=sensor.substrate_6_substrate_6_vwc_coco_coir
 ZONE_6_EC_SENSORS=sensor.substrate_6_substrate_6_pwec
 ZONE_6_PLANT_COUNT=4
@@ -66,12 +66,12 @@ ZONE_6_SHOT_MULTIPLIER=1.0
 # HARDWARE
 # ============================================================================
 # No dedicated pump — constant pressure switch auto-starts pump when mainline opens.
-# switch.gw_mainline = opens/closes flow to tables (pump follows automatically).
-# switch.gw_manifold = tank filling/mixing only, NOT in the irrigation path.
-# switch.gw_mains_water = fresh water fill to tank, not for direct feeding.
+# switch.irrigation_mainline = opens/closes flow to tables (pump follows automatically).
+# switch.irrigation_manifold = tank filling/mixing only, NOT in the irrigation path.
+# switch.irrigation_mains_water = fresh water fill to tank, not for direct feeding.
 PUMP_SWITCH=
-MAIN_LINE_SWITCH=switch.gw_mainline
-WASTE_SWITCH=switch.gw_manifold
+MAIN_LINE_SWITCH=switch.irrigation_mainline
+WASTE_SWITCH=switch.irrigation_manifold
 
 # ============================================================================
 # LIGHTS
@@ -81,11 +81,11 @@ LIGHTS_ON_TIME=08:00
 LIGHTS_OFF_TIME=20:00
 
 # ============================================================================
-# ENVIRONMENTAL SENSORS (GW averaged template sensors)
+# ENVIRONMENTAL SENSORS (Irrigation averaged template sensors)
 # ============================================================================
-TEMPERATURE_SENSOR=sensor.gw_room_1_temp
-HUMIDITY_SENSOR=sensor.gw_room_1_rh
-VPD_SENSOR=sensor.gw_room_1_vpd
+TEMPERATURE_SENSOR=sensor.irrigation_room_1_temp
+HUMIDITY_SENSOR=sensor.irrigation_room_1_rh
+VPD_SENSOR=sensor.irrigation_room_1_vpd
 # No tank level sensor wired yet
 # WATER_LEVEL_SENSOR=
 NOTIFICATION_SERVICE=notify.mobile_app_damians_iphone

--- a/dashboards/co2_environment.yaml
+++ b/dashboards/co2_environment.yaml
@@ -46,7 +46,7 @@ views:
               only.
 
 
-              **Enable**: `GW CO2 Enabled` must be ON. Independent of irrigation
+              **Enable**: `Irrigation CO2 Enabled` must be ON. Independent of irrigation
               and environment.
 
 
@@ -69,7 +69,7 @@ views:
               night target is for your reference / future use.
 
 
-              **Enable**: `GW Environment Enabled` must be ON. Independent of
+              **Enable**: `Irrigation Environment Enabled` must be ON. Independent of
               irrigation and CO2.
 
 
@@ -81,13 +81,13 @@ views:
 
               | System | Enable Flag | What It Controls |
               |--------|------------|-----------------|
-              | CO2 | `GW CO2 Enabled` | CO2 solenoid injection |
-              | Environment | `GW Environment Enabled` | Dehumidifiers, humidifier |
-              | GW Irrigation | `GW Irrigation Enabled` | Timer-based table watering |
+              | CO2 | `Irrigation CO2 Enabled` | CO2 solenoid injection |
+              | Environment | `Irrigation Environment Enabled` | Dehumidifiers, humidifier |
+              | Irrigation | `Irrigation Enabled` | Timer-based table watering |
               | Crop Steering | `CS System Enabled` | AI-driven table watering |
 
 
-              All four are independent. `GW Master Enable` is the panic button —
+              All four are independent. `Irrigation Master Enable` is the panic button —
               the emergency stop script turns it OFF and closes all valves
               including CO2.
 
@@ -98,7 +98,7 @@ views:
               ### Maintenance Mode
 
 
-              Turning on `Maintenance Mode` blocks irrigation (both GW and CS)
+              Turning on `Maintenance Mode` blocks irrigation (both Irrigation and CS)
               and closes all valves. It does NOT automatically stop CO2 or
               environment control, but it's good practice to disable those
               manually if you're working in the room.
@@ -214,7 +214,7 @@ views:
             show_header_toggle: false
             entities:
               - entity: input_boolean.irrigation_enable
-                name: "GW Master Enable"
+                name: "Irrigation Master Enable"
                 secondary_info: "Panic button — OFF closes all valves including CO2"
               - entity: input_boolean.irrigation_maintenance_mode
                 name: "Maintenance Mode"

--- a/dashboards/crop_steering.yaml
+++ b/dashboards/crop_steering.yaml
@@ -44,22 +44,22 @@ views:
             title: "Infrastructure"
             show_header_toggle: false
             entities:
-              - entity: switch.gw_mainline
+              - entity: switch.irrigation_mainline
                 name: "Mainline"
                 secondary_info: last-changed
-              - entity: switch.gw_mains_water
+              - entity: switch.irrigation_mains_water
                 name: "Mains Water"
                 secondary_info: last-changed
-              - entity: switch.gw_manifold
+              - entity: switch.irrigation_manifold
                 name: "Manifold"
                 secondary_info: last-changed
-              - entity: switch.gw_tank_fill_valve
+              - entity: switch.irrigation_tank_fill_valve
                 name: "Tank Fill"
                 secondary_info: last-changed
-              - entity: switch.gw_waste_valve
+              - entity: switch.irrigation_waste_valve
                 name: "Waste"
                 secondary_info: last-changed
-              - entity: switch.gw_recirculation_valve
+              - entity: switch.irrigation_recirculation_valve
                 name: "Recirculation"
                 secondary_info: last-changed
 
@@ -70,22 +70,22 @@ views:
             title: "Valves"
             show_header_toggle: false
             entities:
-              - entity: switch.gw_table_1_valve
+              - entity: switch.irrigation_table_1_valve
                 name: "Table 1"
                 secondary_info: last-changed
-              - entity: switch.gw_table_2_valve
+              - entity: switch.irrigation_table_2_valve
                 name: "Table 2"
                 secondary_info: last-changed
-              - entity: switch.gw_table_3_valve
+              - entity: switch.irrigation_table_3_valve
                 name: "Table 3"
                 secondary_info: last-changed
-              - entity: switch.gw_table_4_valve
+              - entity: switch.irrigation_table_4_valve
                 name: "Table 4"
                 secondary_info: last-changed
-              - entity: switch.gw_table_5_valve
+              - entity: switch.irrigation_table_5_valve
                 name: "Table 5"
                 secondary_info: last-changed
-              - entity: switch.gw_table_6_valve
+              - entity: switch.irrigation_table_6_valve
                 name: "Table 6"
                 secondary_info: last-changed
 

--- a/dashboards/irrigation.yaml
+++ b/dashboards/irrigation.yaml
@@ -18,7 +18,7 @@ views:
             show_header_toggle: false
             entities:
               - entity: input_boolean.irrigation_enable
-                name: GW System
+                name: Irrigation System
                 icon: mdi:power
               - entity: input_boolean.irrigation_maintenance_mode
                 name: Maintenance
@@ -1064,13 +1064,13 @@ views:
             title: "Table 1 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_1_vwc_health
+              - entity: sensor.sensor_irrigation_table_1_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_1_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_1_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_1_ec_health
+              - entity: sensor.sensor_irrigation_table_1_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_1_ec_reliability
+              - entity: sensor.sensor_irrigation_table_1_ec_reliability
                 name: EC Reliability
 
       # ── Table 2 Health ────────────────────────────────────────────────────
@@ -1080,13 +1080,13 @@ views:
             title: "Table 2 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_2_vwc_health
+              - entity: sensor.sensor_irrigation_table_2_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_2_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_2_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_2_ec_health
+              - entity: sensor.sensor_irrigation_table_2_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_2_ec_reliability
+              - entity: sensor.sensor_irrigation_table_2_ec_reliability
                 name: EC Reliability
 
       # ── Table 3 Health ────────────────────────────────────────────────────
@@ -1096,13 +1096,13 @@ views:
             title: "Table 3 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_3_vwc_health
+              - entity: sensor.sensor_irrigation_table_3_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_3_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_3_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_3_ec_health
+              - entity: sensor.sensor_irrigation_table_3_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_3_ec_reliability
+              - entity: sensor.sensor_irrigation_table_3_ec_reliability
                 name: EC Reliability
 
       # ── Table 4 Health ────────────────────────────────────────────────────
@@ -1112,13 +1112,13 @@ views:
             title: "Table 4 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_4_vwc_health
+              - entity: sensor.sensor_irrigation_table_4_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_4_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_4_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_4_ec_health
+              - entity: sensor.sensor_irrigation_table_4_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_4_ec_reliability
+              - entity: sensor.sensor_irrigation_table_4_ec_reliability
                 name: EC Reliability
 
       # ── Table 5 Health ────────────────────────────────────────────────────
@@ -1128,13 +1128,13 @@ views:
             title: "Table 5 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_5_vwc_health
+              - entity: sensor.sensor_irrigation_table_5_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_5_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_5_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_5_ec_health
+              - entity: sensor.sensor_irrigation_table_5_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_5_ec_reliability
+              - entity: sensor.sensor_irrigation_table_5_ec_reliability
                 name: EC Reliability
 
       # ── Table 6 Health ────────────────────────────────────────────────────
@@ -1144,13 +1144,13 @@ views:
             title: "Table 6 Sensor Health"
             show_header_toggle: false
             entities:
-              - entity: sensor.sensor_gw_table_6_vwc_health
+              - entity: sensor.sensor_irrigation_table_6_vwc_health
                 name: VWC Health
-              - entity: sensor.sensor_gw_table_6_vwc_reliability
+              - entity: sensor.sensor_irrigation_table_6_vwc_reliability
                 name: VWC Reliability
-              - entity: sensor.sensor_gw_table_6_ec_health
+              - entity: sensor.sensor_irrigation_table_6_ec_health
                 name: EC Health
-              - entity: sensor.sensor_gw_table_6_ec_reliability
+              - entity: sensor.sensor_irrigation_table_6_ec_reliability
                 name: EC Reliability
 
   # ═══════════════════════════════════════════════════════════════════════════

--- a/dashboards/legacy_irrigation.yaml
+++ b/dashboards/legacy_irrigation.yaml
@@ -1,7 +1,7 @@
-title: "GW Irrigation"
+title: "Irrigation"
 views:
-  - title: GW Irrigation
-    path: gw-irrigation
+  - title: Irrigation
+    path: irrigation
     icon: mdi:water-sync
     type: sections
     max_columns: 4
@@ -13,7 +13,7 @@ views:
         cards:
           - type: markdown
             content: >
-              ## GW Irrigation — How It Works
+              ## Irrigation — How It Works
 
 
               This dashboard controls the **Irrigation timer-based irrigation
@@ -24,7 +24,7 @@ views:
 
               ### How It Runs
 
-              1. The automation `GW Irrigation Scheduler` fires every 5 minutes
+              1. The automation `Irrigation Scheduler` fires every 5 minutes
               and checks if enough time has passed since the last cycle
               (controlled by **Cycle Interval**).
 
@@ -53,25 +53,24 @@ views:
               ### Relationship to Other Systems
 
               - **Crop Steering AI**: If you are using the Crop Steering
-              dashboard for irrigation, **GW Irrigation Enabled should be OFF**
+              dashboard for irrigation, **Irrigation Enabled should be OFF**
               to prevent double-watering. Both systems control the same physical
               valves.
 
-              - **CO2 & Environment**: Completely independent. Turning GW
-              Irrigation off has no effect on CO2 or temp/RH control.
+              - **CO2 & Environment**: Completely independent. Turning irrigation off has no effect on CO2 or temp/RH control.
 
-              - **GW Table Enables**: These flags are respected by BOTH this
+              - **Irrigation Table Enables**: These flags are respected by BOTH this
               system and the Crop Steering AI. Turning off a table here blocks
               it everywhere.
 
 
               ### Enable Hierarchy
 
-              For the GW scheduler to water a table, ALL of these must be true:
+              For the Irrigation scheduler to water a table, ALL of these must be true:
 
-              1. `GW Master Enable` = ON
+              1. `Irrigation Master Enable` = ON
 
-              2. `GW Irrigation Enabled` = ON
+              2. `Irrigation Enabled` = ON
 
               3. `Maintenance Mode` = OFF
 
@@ -90,10 +89,10 @@ views:
             show_header_toggle: false
             entities:
               - entity: input_boolean.irrigation_enable
-                name: "GW Master Enable"
+                name: "Irrigation Master Enable"
                 secondary_info: "Master kill switch — also affects emergency stop script"
               - entity: input_boolean.irrigation_irrigation_enabled
-                name: "GW Irrigation Enabled"
+                name: "Irrigation Enabled"
                 secondary_info: "Timer-based watering — OFF when using Crop Steering AI"
               - entity: input_boolean.irrigation_maintenance_mode
                 name: "Maintenance Mode"

--- a/packages/irrigation/00_core.yaml
+++ b/packages/irrigation/00_core.yaml
@@ -21,7 +21,7 @@ script:
   # Closes every valve and disables the pack immediately.
   # Called by watchdog automations and can be triggered manually.
   irrigation_emergency_stop:
-    alias: "GW Emergency Stop"
+    alias: "Irrigation Emergency Stop"
     icon: mdi:stop-circle-outline
     description: >
       Immediately close all valves, turn off mains water, and disable the
@@ -51,7 +51,7 @@ script:
       - alias: "Notify operators"
         action: notify.notify              # SITE: replace with your notify target
         data:
-          title: "🚨 GW EMERGENCY STOP"
+          title: "🚨 Irrigation EMERGENCY STOP"
           message: >
             All Irrigation valves closed and pack disabled at
             {{ now().strftime('%H:%M:%S %d/%m/%Y') }}.
@@ -59,12 +59,12 @@ script:
 
   # SEND ALERT (reusable helper for all automations)
   irrigation_send_alert:
-    alias: "GW Send Alert"
+    alias: "Irrigation Send Alert"
     icon: mdi:bell-alert
     fields:
       title:
         description: "Alert title"
-        default: "GW Alert"
+        default: "Irrigation Alert"
       message:
         description: "Alert body"
         default: ""
@@ -85,7 +85,7 @@ automation:
 
   # Pack startup – log that the pack loaded successfully
   - id: irrigation_pack_startup
-    alias: "GW Pack Startup"
+    alias: "Irrigation Pack Startup"
     description: "Fires once on HA start to confirm pack is active"
     trigger:
       - trigger: homeassistant

--- a/packages/irrigation/10_mapping.yaml
+++ b/packages/irrigation/10_mapping.yaml
@@ -53,48 +53,48 @@
 input_boolean:
   # Master on/off for the entire irrigation pack
   irrigation_enable:
-    name: "GW Master Enable"
+    name: "Irrigation Master Enable"
     icon: mdi:power
 
-  # GW timer-based irrigation on/off (independent of CO2 and environment).
+  # Irrigation timer-based irrigation on/off (independent of CO2 and environment).
   # Turn OFF when using Crop Steering AI for irrigation instead.
   irrigation_irrigation_enabled:
-    name: "GW Irrigation Enabled"
+    name: "Irrigation Enabled"
     icon: mdi:water-sync
 
   # CO2 injection on/off (independent of irrigation and environment).
   irrigation_co2_enabled:
-    name: "GW CO2 Enabled"
+    name: "Irrigation CO2 Enabled"
     icon: mdi:molecule-co2
 
   # Temperature and humidity control on/off (independent of irrigation and CO2).
   irrigation_environment_enabled:
-    name: "GW Environment Enabled"
+    name: "Irrigation Environment Enabled"
     icon: mdi:thermometer
 
   # Suspend all irrigation without disabling sensors / alerts
   irrigation_maintenance_mode:
-    name: "GW Maintenance Mode"
+    name: "Irrigation Maintenance Mode"
     icon: mdi:wrench
 
   # Per-table enable flags - logic pack ignores disabled tables
   irrigation_table_1_enabled:
-    name: "GW Table 1 Enabled"
+    name: "Irrigation Table 1 Enabled"
     icon: mdi:numeric-1-circle
   irrigation_table_2_enabled:
-    name: "GW Table 2 Enabled"
+    name: "Irrigation Table 2 Enabled"
     icon: mdi:numeric-2-circle
   irrigation_table_3_enabled:
-    name: "GW Table 3 Enabled"
+    name: "Irrigation Table 3 Enabled"
     icon: mdi:numeric-3-circle
   irrigation_table_4_enabled:
-    name: "GW Table 4 Enabled"
+    name: "Irrigation Table 4 Enabled"
     icon: mdi:numeric-4-circle
   irrigation_table_5_enabled:
-    name: "GW Table 5 Enabled"
+    name: "Irrigation Table 5 Enabled"
     icon: mdi:numeric-5-circle
   irrigation_table_6_enabled:
-    name: "GW Table 6 Enabled"
+    name: "Irrigation Table 6 Enabled"
     icon: mdi:numeric-6-circle
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ template:
       # ROOM 1 TEMPERATURE
       # Source: averaged Environmentals calibrated sensors (ESPHome)
       - unique_id: irrigation_room_1_temp
-        name: "GW Room 1 Temp"
+        name: "Irrigation Room 1 Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -135,7 +135,7 @@ template:
       # ROOM 1 RELATIVE HUMIDITY
       # Source: averaged Environmentals calibrated humidity sensors (ESPHome)
       - unique_id: irrigation_room_1_rh
-        name: "GW Room 1 RH"
+        name: "Irrigation Room 1 RH"
         unit_of_measurement: "%"
         device_class: humidity
         state_class: measurement
@@ -161,7 +161,7 @@ template:
       # ROOM 1 CO2
       # Source: averaged CO2 sensors (ESPHome)
       - unique_id: irrigation_room_1_co2
-        name: "GW Room 1 CO2"
+        name: "Irrigation Room 1 CO2"
         unit_of_measurement: "ppm"
         device_class: carbon_dioxide
         state_class: measurement
@@ -187,7 +187,7 @@ template:
       # ROOM 1 VPD
       # Source: averaged VPD from CO2 sensors (ESPHome)
       - unique_id: irrigation_room_1_vpd
-        name: "GW Room 1 VPD"
+        name: "Irrigation Room 1 VPD"
         unit_of_measurement: "kPa"
         state_class: measurement
         icon: mdi:leaf
@@ -216,7 +216,7 @@ template:
       # Required for: VPD-based dehumidifier targeting, AC RH guard
       # Replace 'unavailable' with real sensor entity once installed
       - unique_id: irrigation_leaf_temp
-        name: "GW Leaf Temperature"
+        name: "Irrigation Leaf Temperature"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -242,7 +242,7 @@ template:
       #     {{ (vals | sum / vals | length) | round(1) if vals else 'unavailable' }}
       # ==============================================================
       - unique_id: irrigation_table_1_vwc
-        name: "GW Table 1 VWC"
+        name: "Irrigation Table 1 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -253,7 +253,7 @@ template:
         # MAPPED - sensor.substrate_1_substrate_1_vwc_coco_coir
 
       - unique_id: irrigation_table_2_vwc
-        name: "GW Table 2 VWC"
+        name: "Irrigation Table 2 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -264,7 +264,7 @@ template:
         # MAPPED - sensor.substrate_2_substrate_2_vwc_coco_coir
 
       - unique_id: irrigation_table_3_vwc
-        name: "GW Table 3 VWC"
+        name: "Irrigation Table 3 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -275,7 +275,7 @@ template:
         # MAPPED - sensor.substrate_3_substrate_3_vwc_coco_coir
 
       - unique_id: irrigation_table_4_vwc
-        name: "GW Table 4 VWC"
+        name: "Irrigation Table 4 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -286,7 +286,7 @@ template:
         # MAPPED - sensor.substrate_4_substrate_4_vwc_coco_coir
 
       - unique_id: irrigation_table_5_vwc
-        name: "GW Table 5 VWC"
+        name: "Irrigation Table 5 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -297,7 +297,7 @@ template:
         # MAPPED - sensor.substrate_5_substrate_5_vwc_coco_coir
 
       - unique_id: irrigation_table_6_vwc
-        name: "GW Table 6 VWC"
+        name: "Irrigation Table 6 VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -310,7 +310,7 @@ template:
       # AVERAGE VWC (aggregate across all tables with valid readings)
       # This drives P0/P1/P2/P3 phase transitions in crop steering
       - unique_id: irrigation_average_vwc
-        name: "GW Average VWC"
+        name: "Irrigation Average VWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -336,7 +336,7 @@ template:
       # TODO: Replace with real EC probe entity IDs
       # ==============================================================
       - unique_id: irrigation_table_1_ec
-        name: "GW Table 1 EC"
+        name: "Irrigation Table 1 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -347,7 +347,7 @@ template:
         # MAPPED - sensor.substrate_1_substrate_1_pwec
 
       - unique_id: irrigation_table_2_ec
-        name: "GW Table 2 EC"
+        name: "Irrigation Table 2 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -358,7 +358,7 @@ template:
         # MAPPED - sensor.substrate_2_substrate_2_pwec
 
       - unique_id: irrigation_table_3_ec
-        name: "GW Table 3 EC"
+        name: "Irrigation Table 3 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -369,7 +369,7 @@ template:
         # MAPPED - sensor.substrate_3_substrate_3_pwec
 
       - unique_id: irrigation_table_4_ec
-        name: "GW Table 4 EC"
+        name: "Irrigation Table 4 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -380,7 +380,7 @@ template:
         # MAPPED - sensor.substrate_4_substrate_4_pwec
 
       - unique_id: irrigation_table_5_ec
-        name: "GW Table 5 EC"
+        name: "Irrigation Table 5 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -391,7 +391,7 @@ template:
         # MAPPED - sensor.substrate_5_substrate_5_pwec
 
       - unique_id: irrigation_table_6_ec
-        name: "GW Table 6 EC"
+        name: "Irrigation Table 6 EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -403,7 +403,7 @@ template:
 
       # AVERAGE EC (aggregate across all tables with valid readings)
       - unique_id: irrigation_average_ec
-        name: "GW Average EC"
+        name: "Irrigation Average EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -429,7 +429,7 @@ template:
       # ==============================================================
 
       - unique_id: irrigation_table_1_substrate_temp
-        name: "GW Table 1 Substrate Temp"
+        name: "Irrigation Table 1 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -440,7 +440,7 @@ template:
           {{ states('sensor.substrate_1_substrate_1_temperature') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_table_2_substrate_temp
-        name: "GW Table 2 Substrate Temp"
+        name: "Irrigation Table 2 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -451,7 +451,7 @@ template:
           {{ states('sensor.substrate_2_substrate_2_temperature') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_table_3_substrate_temp
-        name: "GW Table 3 Substrate Temp"
+        name: "Irrigation Table 3 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -462,7 +462,7 @@ template:
           {{ states('sensor.substrate_3_substrate_3_temperature') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_table_4_substrate_temp
-        name: "GW Table 4 Substrate Temp"
+        name: "Irrigation Table 4 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -473,7 +473,7 @@ template:
           {{ states('sensor.substrate_4_substrate_4_temperature') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_table_5_substrate_temp
-        name: "GW Table 5 Substrate Temp"
+        name: "Irrigation Table 5 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -484,7 +484,7 @@ template:
           {{ states('sensor.substrate_5_substrate_5_temperature') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_table_6_substrate_temp
-        name: "GW Table 6 Substrate Temp"
+        name: "Irrigation Table 6 Substrate Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -496,7 +496,7 @@ template:
 
       # Raw/repurposed substrate probe passthroughs
       - unique_id: irrigation_substrate_probe_a_vwc
-        name: "GW Substrate Probe A vWC"
+        name: "Irrigation Substrate Probe A vWC"
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:water-percent
@@ -506,7 +506,7 @@ template:
           {{ states('sensor.co2_2_substrate_3_vwc') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_substrate_probe_a_ec
-        name: "GW Substrate Probe A EC"
+        name: "Irrigation Substrate Probe A EC"
         unit_of_measurement: "EC (ppm500)"
         state_class: measurement
         icon: mdi:flash
@@ -516,7 +516,7 @@ template:
           {{ states('sensor.co2_2_substrate_3_pwec') not in ['unknown','unavailable'] }}
 
       - unique_id: irrigation_substrate_probe_a_temp
-        name: "GW Substrate Probe A Temp"
+        name: "Irrigation Substrate Probe A Temp"
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement
@@ -530,7 +530,7 @@ template:
       # Required for: Tank refill and dose pH verification
       # TODO: Replace with real pH sensor entity_id
       - unique_id: irrigation_tank_ph
-        name: "GW Tank pH"
+        name: "Irrigation Tank pH"
         state_class: measurement
         icon: mdi:flask
         state: "unavailable"
@@ -541,7 +541,7 @@ template:
       # Required for: Tank refill and dose EC verification
       # TODO: Replace with real EC sensor entity_id
       - unique_id: irrigation_tank_ec
-        name: "GW Tank EC"
+        name: "Irrigation Tank EC"
         unit_of_measurement: "mS/cm"
         state_class: measurement
         icon: mdi:flash
@@ -554,7 +554,7 @@ template:
       # LIGHTS ON STATE
       # Source: light.grow_room_all_lights (HA light group)
       - unique_id: irrigation_lights_on
-        name: "GW Lights On"
+        name: "Irrigation Lights On"
         device_class: light
         icon: mdi:lightbulb-group
         state: >
@@ -565,7 +565,7 @@ template:
       # [AUDIT] CRITICAL: irrigation_abort_on_tank_low will NEVER fire until this is
       # mapped to a real float switch sensor. Map BEFORE production deployment.
       - unique_id: irrigation_tank_low
-        name: "GW Tank Low"
+        name: "Irrigation Tank Low"
         device_class: problem
         icon: mdi:water-off
         state: >
@@ -579,7 +579,7 @@ template:
       # [AUDIT] CRITICAL: irrigation_abort_on_leak will NEVER fire until this is
       # mapped to a real leak/moisture sensor. Map BEFORE production deployment.
       - unique_id: irrigation_leak
-        name: "GW Leak Detected"
+        name: "Irrigation Leak Detected"
         device_class: moisture
         icon: mdi:water-alert
         state: >
@@ -589,7 +589,7 @@ template:
         # {{ is_state('binary_sensor.input_10', 'on') }}
 
       - unique_id: irrigation_system_ready
-        name: "GW System Ready"
+        name: "Irrigation System Ready"
         device_class: running
         icon: mdi:check-circle-outline
         state: >
@@ -605,7 +605,7 @@ template:
   - switch:
       # TABLE 1 VALVE - MAPPED to switch.table_1 (KC868 E16S Output 1)
       - unique_id: irrigation_table_1_valve
-        name: "GW Table 1 Valve"
+        name: "Irrigation Table 1 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_1', 'on') }}
@@ -622,7 +622,7 @@ template:
 
       # TABLE 2 VALVE - MAPPED to switch.table_2 (KC868 E16S Output 2)
       - unique_id: irrigation_table_2_valve
-        name: "GW Table 2 Valve"
+        name: "Irrigation Table 2 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_2', 'on') }}
@@ -639,7 +639,7 @@ template:
 
       # TABLE 3 VALVE - MAPPED to switch.table_3 (KC868 E16S Output 3)
       - unique_id: irrigation_table_3_valve
-        name: "GW Table 3 Valve"
+        name: "Irrigation Table 3 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_3', 'on') }}
@@ -656,7 +656,7 @@ template:
 
       # TABLE 4 VALVE - MAPPED to switch.table_4 (KC868 E16S Output 4)
       - unique_id: irrigation_table_4_valve
-        name: "GW Table 4 Valve"
+        name: "Irrigation Table 4 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_4', 'on') }}
@@ -673,7 +673,7 @@ template:
 
       # TABLE 5 VALVE - MAPPED to switch.table_5 (KC868 E16S Output 5)
       - unique_id: irrigation_table_5_valve
-        name: "GW Table 5 Valve"
+        name: "Irrigation Table 5 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_5', 'on') }}
@@ -690,7 +690,7 @@ template:
 
       # TABLE 6 VALVE - MAPPED to switch.table_6 (KC868 E16S Output 6)
       - unique_id: irrigation_table_6_valve
-        name: "GW Table 6 Valve"
+        name: "Irrigation Table 6 Valve"
         icon: mdi:valve
         state: >
           {{ is_state('switch.table_6', 'on') }}
@@ -707,7 +707,7 @@ template:
 
       # MAINS WATER SOLENOID - MAPPED to switch.mains_water (KC868 Output 7)
       - unique_id: irrigation_mains_water
-        name: "GW Mains Water"
+        name: "Irrigation Mains Water"
         icon: mdi:pipe-valve
         state: >
           {{ is_state('switch.mains_water', 'on') }}
@@ -724,7 +724,7 @@ template:
 
       # MAINLINE SOLENOID - MAPPED to switch.mainline (KC868 Output 8)
       - unique_id: irrigation_mainline
-        name: "GW Mainline"
+        name: "Irrigation Mainline"
         icon: mdi:pipe
         state: >
           {{ is_state('switch.mainline', 'on') }}
@@ -741,7 +741,7 @@ template:
 
       # MANIFOLD SOLENOID - MAPPED to switch.manifold (KC868 Output 9)
       - unique_id: irrigation_manifold
-        name: "GW Manifold"
+        name: "Irrigation Manifold"
         icon: mdi:pipe-disconnected
         state: >
           {{ is_state('switch.manifold', 'on') }}
@@ -758,7 +758,7 @@ template:
 
       # CO2 RELAY - MAPPED to switch.solidstate_relay_co2_1_co2_relay_1
       - unique_id: irrigation_co2
-        name: "GW CO2"
+        name: "Irrigation CO2"
         icon: mdi:molecule-co2
         state: >
           {{ is_state('switch.solidstate_relay_co2_1_co2_relay_1', 'on') }}
@@ -775,7 +775,7 @@ template:
 
       # HUMIDIFIER RELAY - MAPPED to switch.solidstate_relay_humidifier_1_humidifier_relay_1
       - unique_id: irrigation_humidifier
-        name: "GW Humidifier"
+        name: "Irrigation Humidifier"
         icon: mdi:air-humidifier
         state: >
           {{ is_state('switch.solidstate_relay_humidifier_1_humidifier_relay_1', 'on') }}
@@ -792,7 +792,7 @@ template:
 
       # DEHUMIDIFIER 1 PLUG - MAPPED to switch.dehumidifier_1_plug (TP-Link Kasa)
       - unique_id: irrigation_dehumidifier_1
-        name: "GW Dehumidifier 1"
+        name: "Irrigation Dehumidifier 1"
         icon: mdi:air-humidifier-off
         state: >
           {{ is_state('switch.dehumidifier_1_plug', 'on') }}
@@ -809,7 +809,7 @@ template:
 
       # DEHUMIDIFIER RELAY 1
       - unique_id: irrigation_dehumidifier_relay_1
-        name: "GW Dehumidifier Relay 1"
+        name: "Irrigation Dehumidifier Relay 1"
         icon: mdi:air-humidifier-off
         state: >
           {{ is_state('switch.left_dehumidifier_1_relay_1', 'on') }}
@@ -826,7 +826,7 @@ template:
 
       # DEHUMIDIFIER RELAY 2
       - unique_id: irrigation_dehumidifier_relay_2
-        name: "GW Dehumidifier Relay 2"
+        name: "Irrigation Dehumidifier Relay 2"
         icon: mdi:air-humidifier-off
         state: >
           {{ is_state('switch.left_dehumidifier_1_relay_2', 'on') }}
@@ -843,7 +843,7 @@ template:
 
       # DEHUMIDIFIER RELAY 3
       - unique_id: irrigation_dehumidifier_relay_3
-        name: "GW Dehumidifier Relay 3"
+        name: "Irrigation Dehumidifier Relay 3"
         icon: mdi:air-humidifier-off
         state: >
           {{ is_state('switch.left_dehumidifier_1_relay_3', 'on') }}
@@ -860,7 +860,7 @@ template:
 
       # DEHUMIDIFIER RELAY 4
       - unique_id: irrigation_dehumidifier_relay_4
-        name: "GW Dehumidifier Relay 4"
+        name: "Irrigation Dehumidifier Relay 4"
         icon: mdi:air-humidifier-off
         state: >
           {{ is_state('switch.left_dehumidifier_1_relay_4', 'on') }}
@@ -882,7 +882,7 @@ template:
       # Required for: Tank refill and dose automation
       # TODO: Replace 'switch.TODO_tank_fill_valve' with real entity
       - unique_id: irrigation_tank_fill_valve
-        name: "GW Tank Fill Valve"
+        name: "Irrigation Tank Fill Valve"
         icon: mdi:pipe-valve
         state: "{{ false }}"
         turn_on:
@@ -899,7 +899,7 @@ template:
       # Required for: Tank mixing during dose cycles
       # TODO: Replace 'switch.TODO_recirculation_valve' with real entity
       - unique_id: irrigation_recirculation_valve
-        name: "GW Recirculation Valve"
+        name: "Irrigation Recirculation Valve"
         icon: mdi:pipe-valve
         state: "{{ false }}"
         turn_on:
@@ -916,7 +916,7 @@ template:
       # Required for: Tank management
       # TODO: Replace with real entity
       - unique_id: irrigation_waste_valve
-        name: "GW Waste Valve"
+        name: "Irrigation Waste Valve"
         icon: mdi:pipe-valve
         state: "{{ false }}"
         turn_on:
@@ -933,7 +933,7 @@ template:
       # Required for: Night-time high CO2 exhaust
       # TODO: Replace with real entity
       - unique_id: irrigation_ceiling_vent
-        name: "GW Ceiling Vent"
+        name: "Irrigation Ceiling Vent"
         icon: mdi:fan
         state: "{{ false }}"
         turn_on:
@@ -977,28 +977,28 @@ input_text:
   # AC UNIT 1
   # TODO: Set to your real climate entity, e.g. climate.grow_room_ac_1
   irrigation_ac_unit_1:
-    name: "GW AC Unit 1 Entity ID"
+    name: "Irrigation AC Unit 1 Entity ID"
     max: 255
     initial: "climate.ac_1_ac_1_2"
     icon: mdi:air-conditioner
 
   # AC UNIT 2
   irrigation_ac_unit_2:
-    name: "GW AC Unit 2 Entity ID"
+    name: "Irrigation AC Unit 2 Entity ID"
     max: 255
     initial: "climate.ac_2_ac_2"
     icon: mdi:air-conditioner
 
   # AC UNIT 3
   irrigation_ac_unit_3:
-    name: "GW AC Unit 3 Entity ID"
+    name: "Irrigation AC Unit 3 Entity ID"
     max: 255
     initial: "climate.ac_3_ac_3"
     icon: mdi:air-conditioner
 
   # AC UNIT 4
   irrigation_ac_unit_4:
-    name: "GW AC Unit 4 Entity ID"
+    name: "Irrigation AC Unit 4 Entity ID"
     max: 255
     initial: "climate.ac_4_ac_4"
     icon: mdi:air-conditioner
@@ -1007,7 +1007,7 @@ input_text:
   # The light group entity for brightness control (light.turn_on with brightness)
   # Default matches existing binary_sensor source
   irrigation_light_group:
-    name: "GW Light Group Entity ID"
+    name: "Irrigation Light Group Entity ID"
     max: 255
     initial: "light.grow_room_all_lights"
     icon: mdi:lightbulb-group
@@ -1015,7 +1015,7 @@ input_text:
   # EXHAUST FAN SPEED (number entity for variable speed)
   # TODO: Replace with real entity - e.g. number.exhaust_fan_speed
   irrigation_exhaust_fan_speed:
-    name: "GW Exhaust Fan Speed Entity ID"
+    name: "Irrigation Exhaust Fan Speed Entity ID"
     max: 255
     initial: "number.TODO_exhaust_fan_speed"
     icon: mdi:fan
@@ -1023,7 +1023,7 @@ input_text:
   # NIGHT HEATING UNIT
   # Which AC unit is designated for night heating (set to one of irrigation_ac_unit_*)
   irrigation_night_heat_unit:
-    name: "GW Night Heating Unit Entity ID"
+    name: "Irrigation Night Heating Unit Entity ID"
     max: 255
     initial: "climate.ac_1_ac_1_2"
     icon: mdi:radiator
@@ -1031,14 +1031,14 @@ input_text:
   # DOSER MQTT TOPIC (for peristaltic dosing pump)
   # TODO: Replace with your dosing system MQTT topic
   irrigation_doser_mqtt_topic:
-    name: "GW Doser MQTT Topic"
+    name: "Irrigation Doser MQTT Topic"
     max: 255
     initial: "TODO/doser/command"
     icon: mdi:flask
 
   # DOSER SERIAL NUMBER
   irrigation_doser_serial:
-    name: "GW Doser Serial Number"
+    name: "Irrigation Doser Serial Number"
     max: 255
     initial: "TODO_SERIAL"
     icon: mdi:barcode

--- a/packages/irrigation/20_model.yaml
+++ b/packages/irrigation/20_model.yaml
@@ -6,7 +6,7 @@
 #           Operators tune these values in the HA UI – no YAML edits needed
 #           after commissioning.
 #
-# All entity names use the "GW …" prefix and irrigation_* entity_ids.
+# All entity names use the "Irrigation …" prefix and irrigation_* entity_ids.
 # No raw hardware entity_ids in this file.
 ###############################################################################
 
@@ -18,14 +18,14 @@ input_datetime:
 
   # Daily irrigation window start (default: 08:00 – at lights-on)
   irrigation_irrigate_start_time:
-    name: "GW Irrigate Start Time"
+    name: "Irrigation Irrigate Start Time"
     has_date: false
     has_time: true
     icon: mdi:clock-start
 
   # Daily irrigation window end (default: 20:00 – 2 h before lights-off)
   irrigation_irrigate_end_time:
-    name: "GW Irrigate End Time"
+    name: "Irrigation Irrigate End Time"
     has_date: false
     has_time: true
     icon: mdi:clock-end
@@ -35,7 +35,7 @@ input_number:
 
   # Minutes between irrigation runs (per enabled table), during window
   irrigation_irrigate_interval_min:
-    name: "GW Irrigate Interval (min)"
+    name: "Irrigation Irrigate Interval (min)"
     min: 5
     max: 240
     step: 5
@@ -45,7 +45,7 @@ input_number:
 
   # Duration each table valve stays open per run
   irrigation_irrigate_duration_sec:
-    name: "GW Irrigate Duration (s)"
+    name: "Irrigation Irrigate Duration (s)"
     min: 10
     max: 300
     step: 5
@@ -55,7 +55,7 @@ input_number:
 
   # Hard maximum any single valve can stay open (watchdog limit)
   irrigation_valve_max_runtime_sec:
-    name: "GW Valve Max Runtime (s)"
+    name: "Irrigation Valve Max Runtime (s)"
     min: 30
     max: 600
     step: 30
@@ -65,7 +65,7 @@ input_number:
 
   # Temperature targets for environment control
   irrigation_temp_target_day:
-    name: "GW Temp Target Day (°C)"
+    name: "Irrigation Temp Target Day (°C)"
     min: 18.0
     max: 32.0
     step: 0.5
@@ -74,7 +74,7 @@ input_number:
     icon: mdi:thermometer-chevron-up
 
   irrigation_temp_target_night:
-    name: "GW Temp Target Night (°C)"
+    name: "Irrigation Temp Target Night (°C)"
     min: 15.0
     max: 28.0
     step: 0.5
@@ -83,7 +83,7 @@ input_number:
     icon: mdi:thermometer-chevron-down
 
   irrigation_temp_high_alert:
-    name: "GW Temp High Alert (°C)"
+    name: "Irrigation Temp High Alert (°C)"
     min: 25.0
     max: 40.0
     step: 0.5
@@ -93,7 +93,7 @@ input_number:
 
   # RH targets
   irrigation_rh_target_day:
-    name: "GW RH Target Day (%)"
+    name: "Irrigation RH Target Day (%)"
     min: 40.0
     max: 80.0
     step: 1.0
@@ -102,7 +102,7 @@ input_number:
     icon: mdi:water-percent
 
   irrigation_rh_target_night:
-    name: "GW RH Target Night (%)"
+    name: "Irrigation RH Target Night (%)"
     min: 40.0
     max: 75.0
     step: 1.0
@@ -111,7 +111,7 @@ input_number:
     icon: mdi:water-percent
 
   irrigation_rh_high_alert:
-    name: "GW RH High Alert (%)"
+    name: "Irrigation RH High Alert (%)"
     min: 60.0
     max: 95.0
     step: 1.0
@@ -121,7 +121,7 @@ input_number:
 
   # CO2 targets (ppm)
   irrigation_co2_target:
-    name: "GW CO2 Target (ppm)"
+    name: "Irrigation CO2 Target (ppm)"
     min: 400
     max: 1500
     step: 50
@@ -130,7 +130,7 @@ input_number:
     icon: mdi:molecule-co2
 
   irrigation_co2_high_alert:
-    name: "GW CO2 High Alert (ppm)"
+    name: "Irrigation CO2 High Alert (ppm)"
     min: 800
     max: 2000
     step: 50
@@ -139,7 +139,7 @@ input_number:
     icon: mdi:molecule-co2
 
   irrigation_co2_low_alert:
-    name: "GW CO2 Low Alert (ppm)"
+    name: "Irrigation CO2 Low Alert (ppm)"
     min: 200
     max: 900
     step: 50
@@ -154,32 +154,32 @@ input_number:
 timer:
 
   irrigation_table_1_run_timer:
-    name: "GW Table 1 Run Timer"
+    name: "Irrigation Table 1 Run Timer"
     icon: mdi:timer
     restore: true
 
   irrigation_table_2_run_timer:
-    name: "GW Table 2 Run Timer"
+    name: "Irrigation Table 2 Run Timer"
     icon: mdi:timer
     restore: true
 
   irrigation_table_3_run_timer:
-    name: "GW Table 3 Run Timer"
+    name: "Irrigation Table 3 Run Timer"
     icon: mdi:timer
     restore: true
 
   irrigation_table_4_run_timer:
-    name: "GW Table 4 Run Timer"
+    name: "Irrigation Table 4 Run Timer"
     icon: mdi:timer
     restore: true
 
   irrigation_table_5_run_timer:
-    name: "GW Table 5 Run Timer"
+    name: "Irrigation Table 5 Run Timer"
     icon: mdi:timer
     restore: true
 
   irrigation_table_6_run_timer:
-    name: "GW Table 6 Run Timer"
+    name: "Irrigation Table 6 Run Timer"
     icon: mdi:timer
     restore: true
 
@@ -193,7 +193,7 @@ template:
 
       # Current active temp target (day vs night based on lights state)
       - unique_id: irrigation_temp_target
-        name: "GW Temp Target"
+        name: "Irrigation Temp Target"
         unit_of_measurement: "°C"
         icon: mdi:thermometer
         state: >
@@ -205,7 +205,7 @@ template:
 
       # Current active RH target
       - unique_id: irrigation_rh_target
-        name: "GW RH Target"
+        name: "Irrigation RH Target"
         unit_of_measurement: "%"
         icon: mdi:water-percent
         state: >
@@ -225,7 +225,7 @@ template:
       #   - tank is NOT low
       #   - current time is within the irrigation window
       - unique_id: irrigation_irrigation_allowed
-        name: "GW Irrigation Allowed"
+        name: "Irrigation Allowed"
         device_class: running
         icon: mdi:water-check
         state: >

--- a/packages/irrigation/30_irrigation.yaml
+++ b/packages/irrigation/30_irrigation.yaml
@@ -20,7 +20,7 @@ script:
   # Opens one table valve for irrigation_irrigate_duration_sec seconds.
   # Infrastructure solenoids (mains/mainline/manifold) must already be open.
   irrigation_run_table:
-    alias: "GW Run Table"
+    alias: "Irrigation Run Table"
     icon: mdi:water
     fields:
       table_valve:
@@ -56,7 +56,7 @@ script:
   # ── FULL IRRIGATION CYCLE ─────────────────────────────────────────────────
   # Opens infrastructure, cycles all enabled tables, closes infrastructure.
   irrigation_run_irrigation_cycle:
-    alias: "GW Run Irrigation Cycle"
+    alias: "Irrigation Run Irrigation Cycle"
     icon: mdi:water-sync
     description: >
       Opens mainline (pump auto-starts via pressure switch) then runs each
@@ -191,7 +191,7 @@ automation:
 
   # ── SCHEDULED IRRIGATION ──────────────────────────────────────────────────
   - id: irrigation_irrigation_scheduler
-    alias: "GW Irrigation Scheduler"
+    alias: "Irrigation Scheduler"
     description: >
       Triggers irrigation cycle every irrigation_irrigate_interval_min minutes
       while irrigation_irrigation_allowed is true.
@@ -221,7 +221,7 @@ automation:
 
   # ── ABORT ON LEAK ─────────────────────────────────────────────────────────
   - id: irrigation_abort_on_leak
-    alias: "GW Abort On Leak"
+    alias: "Irrigation Abort On Leak"
     description: "Immediately close all valves when a leak is detected"
     trigger:
       - trigger: state
@@ -235,7 +235,7 @@ automation:
 
   # ── ABORT ON TANK LOW ─────────────────────────────────────────────────────
   - id: irrigation_abort_on_tank_low
-    alias: "GW Abort On Tank Low"
+    alias: "Irrigation Abort On Tank Low"
     description: "Close all valves and disable pack when tank runs low"
     trigger:
       - trigger: state
@@ -256,13 +256,13 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW Tank Low"
+          title: "⚠️ Irrigation Tank Low"
           message: "Nutrient tank is low – irrigation suspended."
           level: "warning"
 
   # ── MAINTENANCE MODE NOTICE ───────────────────────────────────────────────
   - id: irrigation_maintenance_mode_activated
-    alias: "GW Maintenance Mode Activated"
+    alias: "Irrigation Maintenance Mode Activated"
     trigger:
       - trigger: state
         entity_id: input_boolean.irrigation_maintenance_mode
@@ -283,6 +283,6 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🔧 GW Maintenance Mode ON"
+          title: "🔧 Irrigation Maintenance Mode ON"
           message: "Irrigation suspended for maintenance. All valves closed."
           level: "warning"

--- a/packages/irrigation/40_environment.yaml
+++ b/packages/irrigation/40_environment.yaml
@@ -15,7 +15,7 @@
 automation:
   # ── DEHUMIDIFIER CONTROL ──────────────────────────────────────────────────
   - id: irrigation_dehumidifier_on
-    alias: "GW Dehumidifier On"
+    alias: "Irrigation Dehumidifier On"
     description: "Turn on dehumidifiers when RH exceeds target + 5 %"
     trigger:
       - trigger: template
@@ -53,7 +53,7 @@ automation:
           entity_id: switch.irrigation_dehumidifier_relay_4
 
   - id: irrigation_dehumidifier_off
-    alias: "GW Dehumidifier Off"
+    alias: "Irrigation Dehumidifier Off"
     description: "Turn off dehumidifiers when RH drops to target - 2 %"
     trigger:
       - trigger: template
@@ -74,7 +74,7 @@ automation:
 
   # ── HUMIDIFIER CONTROL ────────────────────────────────────────────────────
   - id: irrigation_humidifier_on
-    alias: "GW Humidifier On"
+    alias: "Irrigation Humidifier On"
     description: "Turn on humidifier when RH drops below target - 5 %"
     trigger:
       - trigger: template
@@ -97,7 +97,7 @@ automation:
           entity_id: switch.irrigation_humidifier
 
   - id: irrigation_humidifier_off
-    alias: "GW Humidifier Off"
+    alias: "Irrigation Humidifier Off"
     description: "Turn off humidifier when RH reaches target + 2 %"
     trigger:
       - trigger: template
@@ -116,7 +116,7 @@ automation:
   # Strategy: when CO2 < 1100, inject in 5-min interval pulses until 1400.
   #           If CO2 > 1800, emergency shutoff.
   - id: irrigation_co2_pulsed_inject
-    alias: "GW CO2 Pulsed Injection"
+    alias: "Irrigation CO2 Pulsed Injection"
     description: "Inject CO2 in 5-min interval pulses when below 1100, target 1400"
     trigger:
       - trigger: numeric_state
@@ -162,7 +162,7 @@ automation:
 
   # Emergency shutoff at 1800 ppm
   - id: irrigation_co2_emergency_off
-    alias: "GW CO2 Emergency Off at 1800 ppm"
+    alias: "Irrigation CO2 Emergency Off at 1800 ppm"
     description: "Force close CO2 solenoid when CO2 exceeds 1800 ppm"
     trigger:
       - trigger: numeric_state
@@ -183,7 +183,7 @@ automation:
 
   # Safety: always close CO2 at lights-off
   - id: irrigation_co2_lights_off_stop
-    alias: "GW CO2 Off at Lights Off"
+    alias: "Irrigation CO2 Off at Lights Off"
     trigger:
       - trigger: state
         entity_id: binary_sensor.irrigation_lights_on
@@ -195,7 +195,7 @@ automation:
 
   # ── HIGH TEMPERATURE ALERT ────────────────────────────────────────────────
   - id: irrigation_high_temp_alert
-    alias: "GW High Temp Alert"
+    alias: "Irrigation High Temp Alert"
     trigger:
       - trigger: numeric_state
         entity_id: sensor.irrigation_room_1_temp
@@ -205,7 +205,7 @@ automation:
     action:
       - action: script.irrigation_send_alert
         data:
-          title: "🌡️ GW High Temp"
+          title: "🌡️ Irrigation High Temp"
           message: >
             Room 1 temperature is {{ states('sensor.irrigation_room_1_temp') }}°C
             (alert threshold: {{ states('input_number.irrigation_temp_high_alert') }}°C).
@@ -213,7 +213,7 @@ automation:
 
   # ── HIGH RH ALERT ─────────────────────────────────────────────────────────
   - id: irrigation_high_rh_alert
-    alias: "GW High RH Alert"
+    alias: "Irrigation High RH Alert"
     trigger:
       - trigger: numeric_state
         entity_id: sensor.irrigation_room_1_rh
@@ -223,7 +223,7 @@ automation:
     action:
       - action: script.irrigation_send_alert
         data:
-          title: "💧 GW High RH"
+          title: "💧 Irrigation High RH"
           message: >
             Room 1 RH is {{ states('sensor.irrigation_room_1_rh') }}%
             (alert threshold: {{ states('input_number.irrigation_rh_high_alert') }}%).
@@ -231,7 +231,7 @@ automation:
 
   # ── CO2 ALERTS ────────────────────────────────────────────────────────────
   - id: irrigation_co2_too_high_alert
-    alias: "GW CO2 Too High Alert"
+    alias: "Irrigation CO2 Too High Alert"
     trigger:
       - trigger: numeric_state
         entity_id: sensor.irrigation_room_1_co2
@@ -244,7 +244,7 @@ automation:
           entity_id: switch.irrigation_co2
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW CO2 Too High"
+          title: "⚠️ Irrigation CO2 Too High"
           message: >
             Room 1 CO2 is {{ states('sensor.irrigation_room_1_co2') }} ppm
             (alert threshold: {{ states('input_number.irrigation_co2_high_alert') }} ppm).
@@ -252,7 +252,7 @@ automation:
           level: "critical"
 
   - id: irrigation_co2_too_low_alert
-    alias: "GW CO2 Too Low Alert"
+    alias: "Irrigation CO2 Too Low Alert"
     trigger:
       - trigger: numeric_state
         entity_id: sensor.irrigation_room_1_co2
@@ -266,7 +266,7 @@ automation:
     action:
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW CO2 Low"
+          title: "⚠️ Irrigation CO2 Low"
           message: >
             Room 1 CO2 is {{ states('sensor.irrigation_room_1_co2') }} ppm —
             check CO2 cylinder supply.

--- a/packages/irrigation/50_alerts_watchdogs.yaml
+++ b/packages/irrigation/50_alerts_watchdogs.yaml
@@ -19,7 +19,7 @@ automation:
   # trigger emergency stop.  Separate automation per table for clarity.
 
   - id: irrigation_watchdog_table_1_valve
-    alias: "GW Watchdog Table 1 Valve"
+    alias: "Irrigation Watchdog Table 1 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_1_valve
@@ -38,7 +38,7 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 1 Valve Stuck"
+          title: "🚨 Irrigation Table 1 Valve Stuck"
           message: >
             Table 1 valve exceeded max runtime
             ({{ states('input_number.irrigation_valve_max_runtime_sec') | int }}s).
@@ -46,7 +46,7 @@ automation:
           level: "critical"
 
   - id: irrigation_watchdog_table_2_valve
-    alias: "GW Watchdog Table 2 Valve"
+    alias: "Irrigation Watchdog Table 2 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_2_valve
@@ -65,13 +65,13 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 2 Valve Stuck"
+          title: "🚨 Irrigation Table 2 Valve Stuck"
           message: >
             Table 2 valve exceeded max runtime. Valve and infrastructure closed.
           level: "critical"
 
   - id: irrigation_watchdog_table_3_valve
-    alias: "GW Watchdog Table 3 Valve"
+    alias: "Irrigation Watchdog Table 3 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_3_valve
@@ -90,12 +90,12 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 3 Valve Stuck"
+          title: "🚨 Irrigation Table 3 Valve Stuck"
           message: "Table 3 valve exceeded max runtime. Valve and infrastructure closed."
           level: "critical"
 
   - id: irrigation_watchdog_table_4_valve
-    alias: "GW Watchdog Table 4 Valve"
+    alias: "Irrigation Watchdog Table 4 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_4_valve
@@ -114,12 +114,12 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 4 Valve Stuck"
+          title: "🚨 Irrigation Table 4 Valve Stuck"
           message: "Table 4 valve exceeded max runtime. Valve and infrastructure closed."
           level: "critical"
 
   - id: irrigation_watchdog_table_5_valve
-    alias: "GW Watchdog Table 5 Valve"
+    alias: "Irrigation Watchdog Table 5 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_5_valve
@@ -138,12 +138,12 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 5 Valve Stuck"
+          title: "🚨 Irrigation Table 5 Valve Stuck"
           message: "Table 5 valve exceeded max runtime. Valve and infrastructure closed."
           level: "critical"
 
   - id: irrigation_watchdog_table_6_valve
-    alias: "GW Watchdog Table 6 Valve"
+    alias: "Irrigation Watchdog Table 6 Valve"
     trigger:
       - trigger: state
         entity_id: switch.irrigation_table_6_valve
@@ -162,7 +162,7 @@ automation:
             - switch.irrigation_manifold
       - action: script.irrigation_send_alert
         data:
-          title: "🚨 GW Table 6 Valve Stuck"
+          title: "🚨 Irrigation Table 6 Valve Stuck"
           message: "Table 6 valve exceeded max runtime. Valve and infrastructure closed."
           level: "critical"
 
@@ -173,7 +173,7 @@ automation:
   # (6 tables × max_runtime + 30s settle) = irrigation_valve_max_runtime_sec × 8
   # ═══════════════════════════════════════════════════════════════════════════
   - id: irrigation_watchdog_mains_water
-    alias: "GW Watchdog Mains Water"
+    alias: "Irrigation Watchdog Mains Water"
     description: "Kill mains water if open longer than 8× valve max runtime"
     trigger:
       - trigger: state
@@ -194,7 +194,7 @@ automation:
   # Alert if the primary temp or RH sensor goes unavailable for > 10 min
   # ═══════════════════════════════════════════════════════════════════════════
   - id: irrigation_watchdog_temp_sensor
-    alias: "GW Watchdog Temp Sensor Offline"
+    alias: "Irrigation Watchdog Temp Sensor Offline"
     trigger:
       - trigger: state
         entity_id: sensor.irrigation_room_1_temp
@@ -209,12 +209,12 @@ automation:
     action:
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW Temp Sensor Offline"
+          title: "⚠️ Irrigation Temp Sensor Offline"
           message: "sensor.irrigation_room_1_temp has been unavailable for 10 min. Check CO2 2 device."
           level: "warning"
 
   - id: irrigation_watchdog_rh_sensor
-    alias: "GW Watchdog RH Sensor Offline"
+    alias: "Irrigation Watchdog RH Sensor Offline"
     trigger:
       - trigger: state
         entity_id: sensor.irrigation_room_1_rh
@@ -229,12 +229,12 @@ automation:
     action:
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW RH Sensor Offline"
+          title: "⚠️ Irrigation RH Sensor Offline"
           message: "sensor.irrigation_room_1_rh unavailable for 10 min. Check CO2 2 device."
           level: "warning"
 
   - id: irrigation_watchdog_co2_sensor
-    alias: "GW Watchdog CO2 Sensor Offline"
+    alias: "Irrigation Watchdog CO2 Sensor Offline"
     trigger:
       - trigger: state
         entity_id: sensor.irrigation_room_1_co2
@@ -252,7 +252,7 @@ automation:
           entity_id: switch.irrigation_co2
       - action: script.irrigation_send_alert
         data:
-          title: "⚠️ GW CO2 Sensor Offline"
+          title: "⚠️ Irrigation CO2 Sensor Offline"
           message: >
             sensor.irrigation_room_1_co2 unavailable for 10 min. CO2 solenoid closed as precaution.
           level: "warning"
@@ -265,7 +265,7 @@ automation:
   # maintenance mode.
   # ═══════════════════════════════════════════════════════════════════════════
   - id: irrigation_valve_open_without_permission
-    alias: "GW Valve Open Without Permission"
+    alias: "Irrigation Valve Open Without Permission"
     description: >
       Close all valves if irrigation_allowed goes false while any valve is open.
       Covers maintenance mode activation, leak trigger, tank low, etc.
@@ -301,7 +301,7 @@ automation:
       - action: system_log.write
         data:
           message: >
-            GW interlock: valves closed because irrigation_irrigation_allowed went false
+            Irrigation interlock: valves closed because irrigation_irrigation_allowed went false
           level: warning
 
 
@@ -311,7 +311,7 @@ automation:
   # Threshold: > 10 lux sustained for 1 min (avoids transient false positives).
   # ═══════════════════════════════════════════════════════════════════════════
   - id: irrigation_ambient_light_dark_period_alert
-    alias: "GW Ambient Light Detected During Dark Period"
+    alias: "Irrigation Ambient Light Detected During Dark Period"
     description: >
       Notify Stephan and Damian if DLight Ambient Light Sensor detects light
       above 10 lux while lights are off. Possible light leak or equipment left on.
@@ -345,7 +345,7 @@ automation:
   # DAILY SAFE-STATE AUDIT  (03:00 – ensure all valves closed in dark period)
   # ═══════════════════════════════════════════════════════════════════════════
   - id: irrigation_daily_safe_state_audit
-    alias: "GW Daily Safe State Audit"
+    alias: "Irrigation Daily Safe State Audit"
     trigger:
       - trigger: time
         at: "03:00:00"
@@ -366,5 +366,5 @@ automation:
             - switch.irrigation_co2
       - action: system_log.write
         data:
-          message: "GW daily safe-state audit completed at 03:00"
+          message: "Irrigation daily safe-state audit completed at 03:00"
           level: info

--- a/www/SYSTEM_GUIDE.html
+++ b/www/SYSTEM_GUIDE.html
@@ -27,7 +27,7 @@
   .cycle{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1.1rem;text-align:center;font-family:'SF Mono',monospace;font-size:.93rem;margin:1.3rem 0;overflow-x:auto;white-space:nowrap}
   .top-btn{position:fixed;bottom:1.5rem;right:1.5rem;background:var(--blue);color:var(--bg);width:38px;height:38px;border-radius:50%;display:flex;align-items:center;justify-content:center;text-decoration:none;font-weight:700;font-size:1.1rem;box-shadow:0 2px 8px rgba(0,0,0,.4);opacity:.8}.top-btn:hover{opacity:1;text-decoration:none}
   .print-btn{position:fixed;bottom:1.5rem;right:4.5rem;background:var(--green);color:var(--bg);border:none;padding:8px 16px;border-radius:6px;cursor:pointer;font-size:.85rem;font-weight:600;box-shadow:0 2px 8px rgba(0,0,0,.4)}.print-btn:hover{background:#4fcc60}
-  .tag{display:inline-block;font-size:.65rem;font-weight:700;padding:1px 6px;border-radius:3px;margin-left:5px;vertical-align:middle}.tag-gw{background:#1a3a2a;color:var(--green);border:1px solid var(--green)}.tag-cs{background:#0d1f3c;color:var(--blue);border:1px solid var(--blue)}.tag-both{background:#2a1a2a;color:var(--purple);border:1px solid var(--purple)}
+  .tag{display:inline-block;font-size:.65rem;font-weight:700;padding:1px 6px;border-radius:3px;margin-left:5px;vertical-align:middle}.tag-irrigation{background:#1a3a2a;color:var(--green);border:1px solid var(--green)}.tag-cs{background:#0d1f3c;color:var(--blue);border:1px solid var(--blue)}.tag-both{background:#2a1a2a;color:var(--purple);border:1px solid var(--purple)}
   @media print{body{background:#fff;color:#000;max-width:100%;padding:.5cm;font-size:10pt;line-height:1.35}h1{color:#000;border-bottom-color:#000;font-size:18pt}h2{color:#222;font-size:13pt;break-after:avoid}h3{color:#333;font-size:11pt;break-after:avoid}.sub{color:#666}a{color:#000}code{background:#f0f0f0;color:#333;border:1px solid #ddd}pre{background:#f8f8f8;border-color:#ccc}pre code{color:#000;border:none}th{background:#e8e8e8;color:#000}td{border-color:#ccc}tr:nth-child(even) td{background:#f5f5f5}tr:hover td{background:#f5f5f5}.toc{background:#f8f8f8;border-color:#ccc;break-inside:avoid}.toc a{color:#333}.phase{background:#f8f8f8}.box{border-width:1px}.warn{background:#fff8e1;border-color:#f9a825}.danger{background:#ffebee;border-color:#e53935}.info{background:#e3f2fd;border-color:#1976d2}.ok{background:#e8f5e9;border-color:#4caf50}.unmapped{background:#f3e5f5;border-color:#9c27b0}.cycle{background:#f8f8f8;border-color:#ccc}.top-btn,.print-btn{display:none}.tag{border:1px solid #999;color:#333;background:#eee}table{break-inside:auto;font-size:9pt}tr{break-inside:avoid}@page{size:A4;margin:12mm}}
   @media(max-width:768px){body{padding:1rem}h1{font-size:1.5rem}.toc{columns:1}table{font-size:.8rem}td,th{padding:.3rem .45rem}}
   /* ─── Visuals & Charts ─────────────────────────────────────────────────── */
@@ -78,7 +78,7 @@
 <li><a href="#s3">Architecture &amp; Data Flow</a></li>
 <li><a href="#s4">The Four Phases (P0&ndash;P3)</a></li>
 <li><a href="#s5">Daily Cycle</a></li>
-<li><a href="#s6">GW Time-Based Scheduler</a></li>
+<li><a href="#s6">Irrigation Time-Based Scheduler</a></li>
 <li><a href="#s7">Environment Control</a></li>
 <li><a href="#s8">Entity Reference &amp; Dashboard Variables</a></li>
 <li><a href="#s9">Configuration Files</a></li>
@@ -102,15 +102,15 @@
 
 <h2 id="s1">1. System Overview</h2>
 <p>This system automates irrigation and climate control for a 6-table cannabis grow room running coco coir with Athena nutrients and GroundWork substrate probes. Two layers run simultaneously:</p>
-<div class="box ok"><h4>Irrigation Package <span class="tag tag-gw">GW</span></h4><p>Time-based irrigation scheduler (should be OFF when crop steering is active), environment control (CO2, dehumidifiers, humidifier), and safety watchdogs. Runs in HA via YAML packages at <code>/config/packages/irrigation/</code>.</p></div>
+<div class="box ok"><h4>Irrigation Package <span class="tag tag-irrigation">Irrigation</span></h4><p>Time-based irrigation scheduler (should be OFF when crop steering is active), environment control (CO2, dehumidifiers, humidifier), and safety watchdogs. Runs in HA via YAML packages at <code>/config/packages/irrigation/</code>.</p></div>
 <div class="box info"><h4>Crop Steering AI <span class="tag tag-cs">CS</span></h4><p>Sensor-driven 4-phase irrigation (P0&ndash;P3) with per-zone control, EC ratio logic, ML prediction, dryback detection, and emergency management. Runs as AppDaemon app + HA custom component. <strong>This is the active irrigation brain.</strong></p></div>
-<div class="box warn"><strong>To prevent double-watering:</strong> Set <code>input_boolean.irrigation_irrigation_enabled</code> to OFF when crop steering is handling irrigation. GW environment controls remain active independently.</div>
+<div class="box warn"><strong>To prevent double-watering:</strong> Set <code>input_boolean.irrigation_irrigation_enabled</code> to OFF when crop steering is handling irrigation. Irrigation environment controls remain active independently.</div>
 
 <hr>
 <h2 id="s2">2. Hardware Map</h2>
 <h3>Irrigation</h3>
 <table>
-<tr><th>Component</th><th>GW Entity</th><th>Raw Entity</th><th>Physical</th></tr>
+<tr><th>Component</th><th>Irrigation Entity</th><th>Raw Entity</th><th>Physical</th></tr>
 <tr><td>Main Line</td><td><code>switch.irrigation_mainline</code></td><td><code>switch.mainline</code></td><td>Mainline solenoid (KC868)</td></tr>
 <tr><td>Zone 1&ndash;6 Valves</td><td><code>switch.irrigation_table_N_valve</code></td><td><code>switch.table_N</code></td><td>Table solenoids (KC868)</td></tr>
 <tr><td>Pump</td><td colspan="2">None &mdash; auto-start</td><td>Constant pressure switch</td></tr>
@@ -122,7 +122,7 @@
 <tr><th>Zone</th><th>VWC</th><th>EC</th></tr>
 <tr><td>1&ndash;6</td><td><code>sensor.substrate_N_substrate_N_vwc_coco_coir</code></td><td><code>sensor.substrate_N_substrate_N_pwec</code></td></tr>
 </table>
-<p>GW mapping layer creates aliases: <code>sensor.irrigation_table_N_vwc</code> / <code>_ec</code> / <code>_substrate_temp</code>. Crop steering reads the raw entities directly.</p>
+<p>Irrigation mapping layer creates aliases: <code>sensor.irrigation_table_N_vwc</code> / <code>_ec</code> / <code>_substrate_temp</code>. Crop steering reads the raw entities directly.</p>
 <h3>Environment</h3>
 <table>
 <tr><th>Sensor</th><th>Entity</th><th>Source</th></tr>
@@ -155,7 +155,7 @@
     |
 Raw entities (sensor.substrate_N_substrate_N_vwc_coco_coir)
     |   [10_mapping.yaml]
-GW contract entities (sensor.irrigation_table_N_vwc)
+Irrigation contract entities (sensor.irrigation_table_N_vwc)
     |
     +-- crop_steering.env
     |
@@ -167,7 +167,7 @@ AppDaemon master app (listen_state + REST API fallback)
     |
 Hardware (valve switches via HA services)</code></pre>
 <div class="box warn"><strong>Entity naming:</strong> Custom component entities have <code>crop_steering_</code> prefix (e.g. <code>switch.crop_steering_system_enabled</code>). AppDaemon tries both prefixed and unprefixed names. Sensors created by AppDaemon use exact IDs shown.</div>
-<h3>GW Package Files</h3>
+<h3>Irrigation Package Files</h3>
 <table>
 <tr><th>File</th><th>Purpose</th></tr>
 <tr><td><code>00_core.yaml</code></td><td>Emergency stop script, alert helper</td></tr>
@@ -267,7 +267,7 @@ flowchart TD
 </div>
 
 <hr>
-<h2 id="s6">6. GW Time-Based Scheduler <span class="tag tag-gw">GW</span></h2>
+<h2 id="s6">6. Irrigation Time-Based Scheduler <span class="tag tag-irrigation">Irrigation</span></h2>
 <div class="box warn"><strong>Must be OFF when crop steering is active.</strong> Set <code>input_boolean.irrigation_irrigation_enabled</code> to OFF.</div>
 <p>Checks every 5 min: system enabled, irrigation enabled, not maintenance, no leak, no tank low, within time window, interval elapsed. Opens mainline, runs each enabled table for configured duration sequentially, closes mainline.</p>
 <table>
@@ -279,7 +279,7 @@ flowchart TD
 </table>
 
 <hr>
-<h2 id="s7">7. Environment Control <span class="tag tag-gw">GW</span></h2>
+<h2 id="s7">7. Environment Control <span class="tag tag-irrigation">Irrigation</span></h2>
 <p>Gated by <code>input_boolean.irrigation_environment_enabled</code>.</p>
 <h3>Dehumidifiers</h3>
 <p>4 relays stagger ON 10s apart. <strong>ON:</strong> RH &gt; target + 5% for 3 min. <strong>OFF:</strong> RH &lt; target &minus; 2% for 2 min. TP-Link plug has separate UI automations at 75%/65%.</p>
@@ -353,14 +353,14 @@ flowchart TD
 <h3>Trigger Buttons</h3>
 <p><code>button.crop_steering_zone_N_trigger_shot</code> &mdash; Delivers one P2-sized shot (5% of substrate volume) immediately. Blocked only if <code>zone_N_manual_override</code> is ON. Works even when auto irrigation is disabled. Useful for manually topping off a zone, testing valve operation, or recovering after a missed irrigation window. The shot is logged to daily volume.</p>
 
-<h3>GW Toggles</h3>
+<h3>Irrigation Toggles</h3>
 <table>
 <tr><th>Entity</th><th>Purpose &amp; Detail</th></tr>
-<tr><td><code>input_boolean.irrigation_enable</code></td><td>GW package master switch. Disabling stops the GW time-based scheduler and all GW environment automations simultaneously. Does not affect Crop Steering.</td></tr>
-<tr><td><code>input_boolean.irrigation_irrigation_enabled</code></td><td><strong>Must be OFF when Crop Steering is active.</strong> Enables the GW time-based irrigation scheduler. When ON, GW will open valves on its own timer regardless of what Crop Steering is doing, causing double-watering.</td></tr>
-<tr><td><code>input_boolean.irrigation_maintenance_mode</code></td><td>Emergency close. When toggled ON, immediately closes all valve switches and blocks any further GW irrigation. Use when you need to physically work on the water system and want a software-level guarantee nothing opens. Turn OFF to resume normal operation.</td></tr>
+<tr><td><code>input_boolean.irrigation_enable</code></td><td>Irrigation package master switch. Disabling stops the Irrigation time-based scheduler and all Irrigation environment automations simultaneously. Does not affect Crop Steering.</td></tr>
+<tr><td><code>input_boolean.irrigation_irrigation_enabled</code></td><td><strong>Must be OFF when Crop Steering is active.</strong> Enables the Irrigation time-based irrigation scheduler. When ON, Irrigation will open valves on its own timer regardless of what Crop Steering is doing, causing double-watering.</td></tr>
+<tr><td><code>input_boolean.irrigation_maintenance_mode</code></td><td>Emergency close. When toggled ON, immediately closes all valve switches and blocks any further Irrigation irrigation. Use when you need to physically work on the water system and want a software-level guarantee nothing opens. Turn OFF to resume normal operation.</td></tr>
 <tr><td><code>input_boolean.irrigation_co2_enabled</code></td><td>Enables the CO2 injection automation. When OFF, the CO2 solenoid will not open regardless of room ppm. Use to disable CO2 without touching the <code>irrigation_co2_target</code> setting.</td></tr>
-<tr><td><code>input_boolean.irrigation_environment_enabled</code></td><td>Gates all GW climate automations: dehumidifiers, humidifier, and CO2 (CO2 also requires its own toggle). Turn OFF to fully disable climate control, e.g. during HVAC maintenance or when running the room manually.</td></tr>
+<tr><td><code>input_boolean.irrigation_environment_enabled</code></td><td>Gates all Irrigation climate automations: dehumidifiers, humidifier, and CO2 (CO2 also requires its own toggle). Turn OFF to fully disable climate control, e.g. during HVAC maintenance or when running the room manually.</td></tr>
 </table>
 
 <h3>Read-Only Sensors: What the Numbers Mean</h3>
@@ -542,7 +542,7 @@ ZONE_1_SHOT_MULTIPLIER=1.0</code></pre>
 <h2 id="s10">10. Dashboards</h2>
 <table>
 <tr><th>Dashboard</th><th>Path</th><th>Purpose</th></tr>
-<tr><td>GW Irrigation</td><td><code>gw-irrigation</code></td><td>Timer scheduler, table enables, hardware, safety</td></tr>
+<tr><td>Irrigation</td><td><code>irrigation</code></td><td>Timer scheduler, table enables, hardware, safety</td></tr>
 <tr><td>Crop Steering AI</td><td><code>crop-steering</code></td><td>Phases, VWC/EC, zone tuning, AI oversight, all parameters</td></tr>
 <tr><td>CO2 &amp; Environment</td><td><code>co2-environment</code></td><td>CO2, dehumidifier, temp/RH targets</td></tr>
 </table>
@@ -727,7 +727,7 @@ flowchart LR
 </pre>
 </div>
 <div class="box info" style="font-size:.82rem"><strong>Why won't my zone water?</strong> Work through this flowchart left to right. The most common reasons (in order of frequency): <strong>1)</strong> Manual override is ON — check <code>zone_N_manual_override</code>. <strong>2)</strong> It already watered too recently — 10-minute cooldown. <strong>3)</strong> Zone hit its daily volume limit — check <code>zone_N_max_daily_volume</code>. <strong>4)</strong> VWC probe is offline or stuck — check ESPHome device status. <strong>5)</strong> VWC is already above field capacity — it doesn't need water yet.</div>
-<h3>GW Safety</h3>
+<h3>Irrigation Safety</h3>
 <table>
 <tr><th>Protection</th><th>What</th></tr>
 <tr><td>Valve watchdog</td><td>Open &gt;180s &rarr; force close + alert</td></tr>
@@ -821,7 +821,7 @@ flowchart LR
 <li><strong>Entity prefix mismatch</strong> &mdash; CS entities have <code>crop_steering_</code> prefix. Dashboard/AppDaemon reference some without. Dual-naming fallback in place.</li>
 <li><strong>get_state() returns None</strong> for CS entities in AppDaemon. Workaround: listen_state + REST API.</li>
 <li><strong>P3 early transition</strong> with slow dryback rate. Self-corrects with data.</li>
-<li><strong>Duplicate dehumidifier automations</strong> &mdash; GW relays + UI TP-Link plug. Different hardware.</li>
+<li><strong>Duplicate dehumidifier automations</strong> &mdash; Irrigation relays + UI TP-Link plug. Different hardware.</li>
 <li><strong>Duplicate CO2 emergency</strong> &mdash; Both package and UI automation close at 1800 ppm.</li>
 </ul>
 <h3>Shot Reference</h3>

--- a/www/irrigation-manual.html
+++ b/www/irrigation-manual.html
@@ -121,7 +121,7 @@ Physical probes (ESPHome)
     ↓
 Raw sensor entities (e.g. sensor.substrate_1_substrate_1_vwc_coco_coir)
     ↓  [10_mapping.yaml averages + rounds values]
-GW contract entities (e.g. sensor.irrigation_table_1_vwc)
+Irrigation contract entities (e.g. sensor.irrigation_table_1_vwc)
     ↓  [crop_steering.env tells the integration where to look]
 Crop Steering entities (e.g. sensor.zone_1_vwc)
 </pre>
@@ -199,7 +199,7 @@ Drippers → Plants → Substrate → Runoff
   <tr><td>Time between cycles</td><td>Schedule tab → Interval</td><td>60 minutes</td></tr>
   <tr><td>Duration per table</td><td>Schedule tab → Duration</td><td>60 seconds</td></tr>
   <tr><td>Which tables are active</td><td>Zone Control tab → Enabled toggle per table</td><td>All off</td></tr>
-  <tr><td>Master on/off</td><td>Command Center → GW System</td><td>Off</td></tr>
+  <tr><td>Master on/off</td><td>Command Center → Irrigation System</td><td>Off</td></tr>
 </table>
 
 <h3>Environment Control</h3>
@@ -284,7 +284,7 @@ Drippers → Plants → Substrate → Runoff
 <div class="steps card">
   <div class="step">Go to the <strong>Command Center</strong> tab.</div>
   <div class="step">Turn <strong>Maintenance Mode OFF</strong> (the toggle should be off/grey).</div>
-  <div class="step">Turn <strong>GW System ON</strong>.</div>
+  <div class="step">Turn <strong>Irrigation System ON</strong>.</div>
   <div class="step">Go to <strong>Zone Control</strong> tab. Enable each table you want to irrigate by toggling <strong>Enabled</strong> on.</div>
   <div class="step">Watch the <strong>System Ready</strong> indicator on the Command Center. It should show a green check mark.</div>
 </div>
@@ -383,7 +383,7 @@ Drippers → Plants → Substrate → Runoff
 <p>AppDaemon adds autonomous phase transitions — the system automatically moves through P0→P1→P2→P3 based on live sensor data instead of requiring manual phase selection.</p>
 
 <div class="info">
-  <strong>You don't need AppDaemon to use the system.</strong> The GW Package handles time-based irrigation and the Crop Steering integration provides all the sensor entities and calculations. AppDaemon just adds autonomous decision-making.
+  <strong>You don't need AppDaemon to use the system.</strong> The Irrigation Package handles time-based irrigation and the Crop Steering integration provides all the sensor entities and calculations. AppDaemon just adds autonomous decision-making.
 </div>
 
 <h3>Installation Steps</h3>
@@ -437,7 +437,7 @@ Drippers → Plants → Substrate → Runoff
 <div class="card">
   <h3>Irrigation won't run</h3>
   <ol>
-    <li>Check <strong>Command Center → GW System</strong> is ON.</li>
+    <li>Check <strong>Command Center → Irrigation System</strong> is ON.</li>
     <li>Check <strong>Maintenance Mode</strong> is OFF.</li>
     <li>Check the current time is within your irrigation window (Schedule tab).</li>
     <li>Check at least one table is enabled (Zone Control tab).</li>


### PR DESCRIPTION
### Motivation
- Remove `GW`/`Green Wave` branding and return the repository to neutral, generic `Irrigation` naming across configuration, dashboards, AppDaemon, and documentation. 
- Ensure entity-id and label consistency so templates, automations, and docs reference a single `irrigation_*` contract rather than `gw_*` variants. 
- Fix duplicated phrasing introduced by an earlier bulk replace (e.g., `Irrigation Irrigation Enabled`) and update user-facing help text to match the new names.

### Description
- Replaced branding and renamed user-facing labels/aliases from `GW`/`Green Wave` to `Irrigation` across YAML packages `packages/irrigation/*`, dashboards in `dashboards/`, AppDaemon config in `appdaemon/apps/apps.yaml`, and environment templates in `crop_steering.env`. 
- Replaced `gw_*` / `gw-` / `gw_` entity-id references with `irrigation_*` / `irrigation-` / `irrigation_` in docs, dashboard YAML, `10_mapping.yaml` template entities, and `apps.yaml` mappings; updated template `name:` strings and automation/script aliases accordingly. 
- Updated system guides and HTML/Markdown manuals (`SYSTEM_GUIDE.html`, `SYSTEM_GUIDE.md`, `www/*`, `www/irrigation-manual.html`) to reflect the new naming and to remove residual `Green Wave` mentions. 
- Cleanups only: no behavioral logic was changed (scripts, automations, and templates keep the same structure and entity semantics where names were updated). 

### Testing
- Ran a repository-wide search `rg -ni "green ?wave|\bgw\b|gw-|gw_" .` and confirmed there are no remaining matches in tracked files. 
- Verified the working tree and recorded commits via `git status --short` and `git show --stat`, producing commits `f733732` and `b2bb725` that successfully applied the renames. 
- Performed additional targeted replacements and re-ran the search and commit steps until `rg` returned no results and `git status` showed a clean working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb71f8d9408323868aab912740f8c4)