### PR TITLE
RootSense v3.0 — Intelligent Crop Steering platform (scaffold + Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to the Advanced Automated Crop Steering System will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 3.0.0-dev "RootSense"
+
+### Added (Phase 0 — scaffolding only, no behaviour change)
+- New `appdaemon/apps/crop_steering/intelligence/` package containing the four
+  RootSense intelligence pillars as opt-in AppDaemon apps:
+  - `root_zone.py` — automated field-capacity detection, dryback episodes,
+    substrate analytics sensors.
+  - `adaptive_irrigation.py` — cultivator-intent slider, profile interpolation,
+    bandit-based shot-size optimisation.
+  - `agronomic.py` — Penman-Monteith transpiration estimate, VPD ceiling per
+    cultivar, nightly run reports.
+  - `orchestration.py` — coordinator with `crop_steering.custom_shot` service,
+    emergency rescue, EC flush guardrails.
+  - `anomaly.py` — cross-cutting anomaly scanner (emitter blockage, EC drift,
+    sensor flat-line, peer-group VWC deviation).
+- Shared infrastructure:
+  - `bus.py` — in-process pub/sub (`RootSenseBus`).
+  - `store.py` — local SQLite analytics store (`rootsense.db`).
+- `docs/upgrade/ROOTSENSE_v3_PLAN.md` — full upgrade plan, feature mapping,
+  testing strategy, and future roadmap.
+- `docs/upgrade/apps.example.yaml` — example AppDaemon app declarations.
+
+### Changed
+- **P0 dryback is now unambiguously "% drop from peak VWC"**, surfaced as two
+  independent operator-facing number entities:
+  - `number.crop_steering_veg_p0_dryback_drop_pct` (range 2–40, default 12).
+  - `number.crop_steering_gen_p0_dryback_drop_pct` (range 2–50, default 22).
+  Defaults follow Athena cannabis guidance (small drop in vegetative growth,
+  larger drop in generative). Both values are read live by the IntentResolver
+  every tick — neither is hard-coded. The interpolated current target is
+  pushed to the existing `number.crop_steering_p0_dryback_drop_percent`
+  entity that the legacy P0-exit predicate already consumes, and exposed as
+  `sensor.crop_steering_p0_dryback_drop_pct_current` for dashboards.
+- Legacy entities `number.crop_steering_veg_dryback_target` and
+  `number.crop_steering_gen_dryback_target` are retained as aliases. Their
+  default values are corrected from `50` / `40` (which were too aggressive
+  under the "drop %" semantic) to the new `12` / `22`. Their min ranges are
+  widened to `2` so existing installs that already configured them lower
+  continue to load without validation errors.
+- `DEFAULT_VEG_P0_DRYBACK_DROP_PCT` / `DEFAULT_GEN_P0_DRYBACK_DROP_PCT`
+  added to `custom_components/crop_steering/const.py` as the single source
+  of truth.
+
+### Notes
+- Existing apps (`master_crop_steering_app.py`, `phase_state_machine.py`,
+  detectors, profiles) are untouched in this commit.
+- Modules are not added to `apps.yaml` automatically; existing installs are
+  unaffected. See `docs/upgrade/apps.example.yaml` to opt in.
+- Full migration to v3.0 happens incrementally across PRs #2–#5 per the plan.
+
 ## [2.3.1] - 2025-01-03
 
 ### 🔧 Critical Fixes & Documentation Overhaul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   testing strategy, and future roadmap.
 - `docs/upgrade/apps.example.yaml` — example AppDaemon app declarations.
 
+### Fixed
+- Testability hardening: moved `ShotCalculator` into new pure helper module `custom_components/crop_steering/calculations.py` so unit tests no longer require a Home Assistant runtime during import.
+
+### Documentation
+- Added `docs/upgrade/GAP_ANALYSIS_2026-05.md` with a full module-by-module gap analysis, prioritized production backlog, and explicit To-Do sequence.
+- Updated README with a dedicated "Upgrade Gap Analysis & To-Do" section linking to the new tracker document.
+
 ### Changed
 - **P0 dryback is now unambiguously "% drop from peak VWC"**, surfaced as two
   independent operator-facing number entities:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 3.0.0-dev "RootSense"
 
+### Added (Phase 1 — Root Zone Intelligence wiring)
+- New shared base `appdaemon/apps/crop_steering/intelligence/base.py` provides
+  module-enable gating and common helpers for all five pillars.
+- 5 module-enable switches in the integration so each pillar is independently
+  toggleable from the HA UI:
+  - `switch.crop_steering_intelligence_root_zone_enabled`
+  - `switch.crop_steering_intelligence_adaptive_enabled`
+  - `switch.crop_steering_intelligence_agronomic_enabled`
+  - `switch.crop_steering_intelligence_orchestrator_enabled`
+  - `switch.crop_steering_intelligence_anomaly_enabled`
+  Default OFF — existing v2.x installs are unaffected on first upgrade.
+- `RootZoneIntelligence` now publishes three live derived sensors per zone
+  (previously stubs):
+  - `sensor.crop_steering_zone_{n}_dryback_velocity_pct_per_hr`
+  - `sensor.crop_steering_zone_{n}_substrate_porosity_estimate_ml_per_pct`
+  - `sensor.crop_steering_zone_{n}_ec_stack_index`
+- Local dryback-episode tracker (`DrybackTracker`) detects peak/valley pairs
+  from the rolling per-zone VWC buffer, persists each episode to
+  `rootsense.db`, publishes `dryback.complete` on the bus, and fires the HA
+  `crop_steering_dryback_complete` event.
+- Recorder includes package: `packages/rootsense/00_recorder.yaml` ensures
+  the new sensors and module switches are kept in HA's history database.
+- Reconciliation document `docs/upgrade/RECONCILIATION.md` mapping the gap
+  analysis P1/P2 items to RootSense plan phases.
+- Unit tests: `tests/intelligence/test_dryback_tracker.py` covers the
+  episode tracker state machine (4 cases, all green).
+
 ### Added (Phase 0 — scaffolding only, no behaviour change)
 - New `appdaemon/apps/crop_steering/intelligence/` package containing the four
   RootSense intelligence pillars as opt-in AppDaemon apps:

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ See `docs/installation_guide.md` for the full step-by-step walkthrough and the [
 
 ---
 
+
+## Upgrade Gap Analysis & To-Do
+
+For the AROYA-equivalent roadmap status, see **`docs/upgrade/GAP_ANALYSIS_2026-05.md`**. It includes a module-by-module gap breakdown, production-readiness risks, and a prioritized implementation backlog.
+
 ## Services
 
 | Service | Required Inputs | What It Does |

--- a/appdaemon/apps/crop_steering/intelligence/__init__.py
+++ b/appdaemon/apps/crop_steering/intelligence/__init__.py
@@ -1,0 +1,26 @@
+"""RootSense intelligence pillars.
+
+Each submodule is an opt-in AppDaemon app or library:
+
+- bus.py                  — in-process pub/sub used by all pillars
+- store.py                — SQLite analytics store (rootsense.db)
+- root_zone.py            — Pillar 1: substrate analytics, field capacity, dryback episodes
+- adaptive_irrigation.py  — Pillar 2: cultivator intent, dynamic shot planning, optimisation loop
+- agronomic.py            — Pillar 3: transpiration, climate-substrate, run analytics
+- orchestration.py        — Pillar 4: coordinator + custom shots + emergency
+- anomaly.py              — cross-cutting anomaly scanner
+
+See docs/upgrade/ROOTSENSE_v3_PLAN.md for the full design.
+"""
+
+__all__ = [
+    "bus",
+    "store",
+    "root_zone",
+    "adaptive_irrigation",
+    "agronomic",
+    "orchestration",
+    "anomaly",
+]
+
+ROOTSENSE_VERSION = "3.0.0-dev"

--- a/appdaemon/apps/crop_steering/intelligence/adaptive_irrigation.py
+++ b/appdaemon/apps/crop_steering/intelligence/adaptive_irrigation.py
@@ -1,0 +1,281 @@
+"""Pillar 2 — Adaptive Irrigation Intelligence.
+
+Cultivator-intent control, dynamic shot planning, continuous optimisation.
+
+Three internal sub-systems:
+
+- IntentResolver — interpolates cultivar profile parameters from a single
+  intent number (-100 = generative, +100 = vegetative) and republishes them
+  to the existing crop-steering number entities.
+- ShotPlanner   — computes shot volume for the next P1/P2 shot from observed
+  field capacity, dryback velocity, and intent.
+- OptimisationLoop — Thompson-sampling bandit (numpy only) that nudges
+  shot-size and inter-shot interval to maximise a reward function balancing
+  dryback-target hit rate vs runoff EC error.
+
+This file is a runnable AppDaemon app. Hardware is never touched directly;
+all shot decisions are emitted as `crop_steering.custom_shot` service calls
+which the orchestration coordinator then arbitrates.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+from .bus import RootSenseBus
+from .store import RootSenseStore
+
+_LOGGER = logging.getLogger(__name__)
+
+INTENT_ENTITY = "number.crop_steering_steering_intent"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint profiles
+# ---------------------------------------------------------------------------
+# Two anchor profiles. Every controller parameter is a linear interpolation
+# between them, parameterised by the cultivator-intent slider.
+#
+# DRYBACK SEMANTIC: "p0_dryback_drop_pct" is the percentage *drop* from peak
+# VWC that ends P0 — NOT the VWC value to dry down to. Matches the existing
+# master_crop_steering_app exit predicate (`dryback_percent >= dryback_target`
+# where dryback_percent = peak - current).
+#
+# Numeric defaults below are only used if the corresponding HA number entity
+# is missing. Normal operation reads:
+#   number.crop_steering_veg_p0_dryback_drop_pct   (vegetative endpoint)
+#   number.crop_steering_gen_p0_dryback_drop_pct   (generative endpoint)
+# so the operator can change either value any time from the UI.
+GENERATIVE_PROFILE = {
+    "p1_target_vwc": 60.0,
+    "p2_vwc_threshold": 55.0,
+    "p0_dryback_drop_pct": 22.0,   # mirrors DEFAULT_GEN_P0_DRYBACK_DROP_PCT
+    "shot_size_pct": 4.0,
+    "ec_target_flush": 3.0,
+}
+VEGETATIVE_PROFILE = {
+    "p1_target_vwc": 70.0,
+    "p2_vwc_threshold": 62.0,
+    "p0_dryback_drop_pct": 12.0,   # mirrors DEFAULT_VEG_P0_DRYBACK_DROP_PCT
+    "shot_size_pct": 6.0,
+    "ec_target_flush": 1.8,
+}
+
+# HA number entities the cultivator edits. The IntentResolver reads from them
+# every tick — so changing a slider in the UI propagates immediately.
+ENTITY_VEG_DRYBACK_DROP = "number.crop_steering_veg_p0_dryback_drop_pct"
+ENTITY_GEN_DRYBACK_DROP = "number.crop_steering_gen_p0_dryback_drop_pct"
+
+# Read-only sensor that surfaces the interpolated current target. Dashboards
+# and the phase state machine can subscribe to either this sensor or to the
+# `number.crop_steering_p0_dryback_drop_percent` entity it maps to via
+# PARAM_TO_ENTITY below.
+SENSOR_CURRENT_DRYBACK_DROP = "sensor.crop_steering_p0_dryback_drop_pct_current"
+
+# Per-parameter HA number entity that the resolver *writes back* to.
+# `p0_dryback_drop_pct` is the interpolated target consumed by the phase
+# state machine; the two endpoint sliders above are inputs, not outputs.
+PARAM_TO_ENTITY = {
+    "p1_target_vwc":          "number.crop_steering_p1_target_vwc",
+    "p2_vwc_threshold":       "number.crop_steering_p2_vwc_threshold",
+    # NB: integration entity is named ..._drop_percent (not _pct) — keep the
+    # external name stable so legacy automations / dashboards don't break.
+    "p0_dryback_drop_pct":    "number.crop_steering_p0_dryback_drop_percent",
+    "shot_size_pct":          "number.crop_steering_p1_initial_shot_size",
+    "ec_target_flush":        "number.crop_steering_ec_target_flush",
+}
+
+
+def lerp(a: float, b: float, t: float) -> float:
+    return a + (b - a) * t
+
+
+@dataclass
+class Posterior:
+    """Normal-gamma posterior for a single zone's reward distribution."""
+    mu: float = 0.0
+    kappa: float = 1.0
+    alpha: float = 2.0
+    beta: float = 1.0
+
+    def update(self, observation: float) -> None:
+        kappa1 = self.kappa + 1
+        mu1 = (self.kappa * self.mu + observation) / kappa1
+        alpha1 = self.alpha + 0.5
+        beta1 = self.beta + (self.kappa * (observation - self.mu) ** 2) / (2 * kappa1)
+        self.mu, self.kappa, self.alpha, self.beta = mu1, kappa1, alpha1, beta1
+
+    def sample(self, rng) -> float:
+        # Thompson sample: tau ~ Gamma(alpha, beta), then mu ~ N(mu, 1/(kappa*tau))
+        tau = rng.gamma(self.alpha, 1.0 / self.beta)
+        sigma = 1.0 / math.sqrt(self.kappa * max(tau, 1e-9))
+        return float(rng.normal(self.mu, sigma))
+
+
+class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
+    def initialize(self) -> None:
+        self.bus = RootSenseBus.instance()
+        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
+        self.store = RootSenseStore(db_path)
+        try:
+            import numpy as np
+            self._rng = np.random.default_rng()
+        except ImportError:
+            self._rng = None
+            self.log("numpy not available — optimisation loop will degrade to greedy", level="WARNING")
+
+        self._posteriors: dict[int, Posterior] = {}
+
+        # Re-publish derived parameters whenever intent changes
+        self.listen_state(self._on_intent_changed, INTENT_ENTITY)
+        # Update reward whenever a dryback completes
+        self.bus.subscribe("dryback.complete", self._on_dryback_complete)
+
+        # Initial publish so derived params are correct on startup
+        self.run_in(self._publish_intent_derived_params, 5)
+
+        self.log("AdaptiveIrrigation ready")
+
+    # ------------------------------------------------------------------ Intent
+
+    def _on_intent_changed(self, _entity, _attr, _old, _new, _kwargs) -> None:
+        self._publish_intent_derived_params({})
+
+    def _publish_intent_derived_params(self, _kwargs: Any) -> None:
+        intent = self._read_intent()
+        t = (intent + 100.0) / 200.0  # 0 = pure generative, 1 = pure vegetative
+
+        # Resolve current endpoints. Dryback endpoints are read live from the
+        # two operator-facing sliders; everything else falls back to the
+        # static profile dicts. This is what makes "% dries back BY" fully
+        # configurable — neither endpoint nor interpolated value is hardcoded.
+        gen_endpoint = dict(GENERATIVE_PROFILE)
+        veg_endpoint = dict(VEGETATIVE_PROFILE)
+        gen_endpoint["p0_dryback_drop_pct"] = self._read_float(
+            ENTITY_GEN_DRYBACK_DROP, default=GENERATIVE_PROFILE["p0_dryback_drop_pct"],
+        )
+        veg_endpoint["p0_dryback_drop_pct"] = self._read_float(
+            ENTITY_VEG_DRYBACK_DROP, default=VEGETATIVE_PROFILE["p0_dryback_drop_pct"],
+        )
+
+        derived = {
+            k: round(lerp(gen_endpoint[k], veg_endpoint[k], t), 2)
+            for k in gen_endpoint
+        }
+        for param, value in derived.items():
+            entity = PARAM_TO_ENTITY.get(param)
+            if entity and self.entity_exists(entity):
+                self.call_service("number/set_value", entity_id=entity, value=value)
+
+        # Surface the interpolated dryback as a sensor as well, so dashboards
+        # can show "current P0 dryback target = 17.4% drop" without having to
+        # subscribe to events.
+        self.set_state(
+            "sensor.crop_steering_p0_dryback_drop_pct_current",
+            state=derived["p0_dryback_drop_pct"],
+            attributes={
+                "veg_endpoint": veg_endpoint["p0_dryback_drop_pct"],
+                "gen_endpoint": gen_endpoint["p0_dryback_drop_pct"],
+                "intent": intent,
+                "semantic": "percentage point drop from peak VWC",
+                "unit_of_measurement": "%",
+                "friendly_name": "P0 dryback target (drop %)",
+                "icon": "mdi:water-minus",
+            },
+        )
+
+        self.bus.publish("intent.changed", {"intent": intent, "derived": derived})
+        self.log("Intent=%s → %s", intent, derived)
+
+    def _read_intent(self) -> float:
+        try:
+            return float(self.get_state(INTENT_ENTITY))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
+        try:
+            return float(self.get_state(entity_id))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    # ------------------------------------------------------------------ ShotPlanner
+
+    def plan_shot(self, zone: int, current_vwc: float, target_vwc: float,
+                  field_capacity_pct: float, substrate_volume_l: float) -> dict[str, Any]:
+        """Compute the next shot for a given zone.
+
+        Returns a payload suitable for the `crop_steering.custom_shot` service.
+        Bounded by hard guardrails.
+        """
+        intent = self._read_intent()
+        deficit_pct = max(0.0, target_vwc - current_vwc)
+
+        # Base volume: water needed to lift VWC from current to target,
+        # assuming 1% VWC == 1% of substrate volume in mL.
+        base_ml = deficit_pct * substrate_volume_l * 10.0  # 1% of 1 L = 10 mL
+
+        # Intent bias: vegetative → +20% volume, generative → -20%
+        intent_bias = 1.0 + (intent / 500.0)
+        ml = base_ml * intent_bias
+
+        # Bandit nudge
+        if self._rng is not None:
+            posterior = self._posteriors.setdefault(zone, self._load_posterior(zone))
+            nudge = posterior.sample(self._rng)
+            ml *= max(0.5, min(1.5, 1.0 + nudge / 10.0))
+
+        # Hard guardrail: never more than 2× field capacity
+        max_ml = field_capacity_pct * substrate_volume_l * 20.0  # 2× FC volume
+        ml = max(50.0, min(ml, max_ml))
+
+        return {
+            "target_zone": zone,
+            "intent": "planned",
+            "volume_ml": round(ml, 1),
+            "tag": f"adaptive:intent={intent:+g}",
+        }
+
+    # ------------------------------------------------------------------ OptimisationLoop
+
+    def _on_dryback_complete(self, _topic: str, payload: dict[str, Any]) -> None:
+        if self._rng is None:
+            return
+        zone = int(payload.get("zone", 0))
+        target = self._read_target_dryback(zone)
+        observed = float(payload.get("pct", 0.0))
+        ec_error = abs(float(payload.get("ec_runoff", 0)) - float(payload.get("ec_feed_target", 0)))
+        reward = -(abs(observed - target)) - 0.5 * ec_error
+
+        posterior = self._posteriors.setdefault(zone, self._load_posterior(zone))
+        posterior.update(reward)
+        self.store.upsert_posterior(zone, posterior.__dict__)
+        self.log("Zone %s reward=%.3f → posterior μ=%.3f", zone, reward, posterior.mu)
+
+    def _load_posterior(self, zone: int) -> Posterior:
+        loaded = self.store.load_posterior(zone)
+        if not loaded:
+            return Posterior()
+        return Posterior(**loaded)
+
+    def _read_target_dryback(self, zone: int) -> float:
+        try:
+            return float(self.get_state(f"number.crop_steering_zone_{zone}_dryback_target"))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 50.0
+
+    # ------------------------------------------------------------------ shims
+    def entity_exists(self, entity_id: str) -> bool:
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/adaptive_irrigation.py
+++ b/appdaemon/apps/crop_steering/intelligence/adaptive_irrigation.py
@@ -22,15 +22,9 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from datetime import datetime
-from pathlib import Path
 from typing import Any
 
-try:
-    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
-except ImportError:  # pragma: no cover
-    hass = type("hass", (), {"Hass": object})  # type: ignore
-
+from .base import IntelligenceApp
 from .bus import RootSenseBus
 from .store import RootSenseStore
 
@@ -121,11 +115,10 @@ class Posterior:
         return float(rng.normal(self.mu, sigma))
 
 
-class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
+class AdaptiveIrrigation(IntelligenceApp):
     def initialize(self) -> None:
         self.bus = RootSenseBus.instance()
-        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
-        self.store = RootSenseStore(db_path)
+        self.store = RootSenseStore(self._state_dir() / "rootsense.db")
         try:
             import numpy as np
             self._rng = np.random.default_rng()
@@ -148,9 +141,13 @@ class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ Intent
 
     def _on_intent_changed(self, _entity, _attr, _old, _new, _kwargs) -> None:
+        if not self._is_module_enabled():
+            return
         self._publish_intent_derived_params({})
 
     def _publish_intent_derived_params(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         intent = self._read_intent()
         t = (intent + 100.0) / 200.0  # 0 = pure generative, 1 = pure vegetative
 
@@ -202,11 +199,7 @@ class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
         except (TypeError, ValueError):
             return 0.0
 
-    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
-        try:
-            return float(self.get_state(entity_id))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return default
+    # _read_float lives on IntelligenceApp.
 
     # ------------------------------------------------------------------ ShotPlanner
 
@@ -248,7 +241,7 @@ class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ OptimisationLoop
 
     def _on_dryback_complete(self, _topic: str, payload: dict[str, Any]) -> None:
-        if self._rng is None:
+        if self._rng is None or not self._is_module_enabled():
             return
         zone = int(payload.get("zone", 0))
         target = self._read_target_dryback(zone)
@@ -273,9 +266,4 @@ class AdaptiveIrrigation(hass.Hass):  # type: ignore[misc]
         except (TypeError, ValueError):
             return 50.0
 
-    # ------------------------------------------------------------------ shims
-    def entity_exists(self, entity_id: str) -> bool:
-        try:
-            return super().entity_exists(entity_id)  # type: ignore[misc]
-        except AttributeError:
-            return self.get_state(entity_id) is not None
+    # entity_exists lives on IntelligenceApp.

--- a/appdaemon/apps/crop_steering/intelligence/agronomic.py
+++ b/appdaemon/apps/crop_steering/intelligence/agronomic.py
@@ -1,0 +1,200 @@
+"""Pillar 3 — Agronomic Intelligence.
+
+- TranspirationModel    : Penman–Monteith approximation per zone.
+- ClimateSubstrateModel : rolling correlation between VPD and dryback velocity.
+- RunAnalytics          : nightly aggregation that emits `crop_steering_run_report`.
+
+This file is a runnable AppDaemon app. It is read-mostly: it consumes
+sensor data and bus events, writes to the analytics store, and emits HA
+events but never schedules irrigation directly.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import statistics
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Deque
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+from .bus import RootSenseBus
+from .store import RootSenseStore
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TranspirationSample:
+    ts: datetime
+    et_ml_per_hr: float
+    vpd_kpa: float
+    ppfd: float
+
+
+class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
+    def initialize(self) -> None:
+        self.bus = RootSenseBus.instance()
+        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
+        self.store = RootSenseStore(db_path)
+
+        cfg = self.args or {}
+        self.air_movement_m_s: float = float(cfg.get("room_air_movement_m_s", 0.3))
+        self.canopy_temp_entity: str | None = cfg.get("canopy_temp_entity")
+        self.air_temp_entity: str | None = cfg.get("air_temp_entity")
+        self.rh_entity: str | None = cfg.get("rh_entity")
+        self.ppfd_entity: str | None = cfg.get("ppfd_entity")
+        self.lights_off_entity: str = cfg.get("lights_off_entity", "binary_sensor.crop_steering_lights")
+
+        self._samples: dict[int, Deque[TranspirationSample]] = defaultdict(lambda: deque(maxlen=720))
+        self._dryback_window: dict[int, Deque[tuple[float, float]]] = defaultdict(lambda: deque(maxlen=120))
+
+        # Compute & publish transpiration every 5 minutes
+        self.run_every(self._publish_transpiration, "now+30", 300)
+
+        # Subscribe to dryback events to feed the climate-substrate correlator
+        self.bus.subscribe("dryback.complete", self._on_dryback_complete)
+
+        # Nightly run report
+        self.run_daily(self._emit_run_report, "23:55:00")
+
+        self.log("AgronomicIntelligence ready")
+
+    # ------------------------------------------------------------------ Transpiration
+
+    def _publish_transpiration(self, _kwargs: Any) -> None:
+        vpd = self._read_vpd_kpa()
+        ppfd = self._read_float(self.ppfd_entity, default=0.0) if self.ppfd_entity else 0.0
+        if vpd is None:
+            return
+        et_total_ml_h = self._penman_monteith_ml_per_hr(vpd_kpa=vpd, ppfd=ppfd)
+        for zone in self._configured_zones():
+            # Per-zone gain calibration TBD in PR #4 — start with global value.
+            self._samples[zone].append(TranspirationSample(
+                ts=datetime.utcnow(), et_ml_per_hr=et_total_ml_h, vpd_kpa=vpd, ppfd=ppfd,
+            ))
+            self.set_state(
+                f"sensor.crop_steering_zone_{zone}_transpiration_ml_per_hr",
+                state=round(et_total_ml_h, 1),
+                attributes={
+                    "vpd_kpa": round(vpd, 3),
+                    "ppfd": round(ppfd, 1),
+                    "unit_of_measurement": "mL/h",
+                    "friendly_name": f"Zone {zone} Transpiration",
+                    "icon": "mdi:water-sync",
+                },
+            )
+
+    def _penman_monteith_ml_per_hr(self, vpd_kpa: float, ppfd: float) -> float:
+        """Hourly transpiration estimate, mL of water per hour per plant.
+
+        Simplified Penman-Monteith: assumes 1 m² leaf area, gamma=0.066 kPa/°C.
+        Real implementation uses canopy LAI from a future vision module; here
+        we approximate ET (mm/h) ≈ k * VPD * f(PPFD), with k tuned in PR #4.
+        """
+        # ET (mm/h) ≈ 0.06 * VPD * (1 + PPFD/2000); 1 mm = 1 L/m²
+        et_mm_h = 0.06 * vpd_kpa * (1.0 + min(ppfd, 2000.0) / 2000.0)
+        # 1 m² leaf area placeholder ⇒ 1 mm = 1000 mL
+        return max(0.0, et_mm_h * 1000.0 / 4.0)  # /4 for "per plant" rough scaling
+
+    def _read_vpd_kpa(self) -> float | None:
+        # Either pull a precomputed VPD sensor, or derive from temp + RH
+        vpd = self.get_state("sensor.crop_steering_vpd")
+        try:
+            return float(vpd)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            pass
+        t = self._read_float(self.air_temp_entity)
+        rh = self._read_float(self.rh_entity)
+        if t is None or rh is None:
+            return None
+        es = 0.6108 * math.exp(17.27 * t / (t + 237.3))
+        ea = es * (rh / 100.0)
+        return max(0.0, es - ea)
+
+    # ------------------------------------------------------------------ Climate↔Substrate
+
+    def _on_dryback_complete(self, _topic: str, payload: dict[str, Any]) -> None:
+        zone = int(payload.get("zone", 0))
+        velocity = float(payload.get("slope_pct_h", 0.0))  # %/hour
+        vpd_avg = float(payload.get("vpd_avg", 0.0))
+        if vpd_avg <= 0:
+            return
+        self._dryback_window[zone].append((vpd_avg, velocity))
+        self._publish_vpd_ceiling(zone)
+
+    def _publish_vpd_ceiling(self, zone: int) -> None:
+        samples = list(self._dryback_window[zone])
+        if len(samples) < 10:
+            return
+        # Find VPD bin where dryback velocity slope sharply increases.
+        sorted_by_vpd = sorted(samples, key=lambda s: s[0])
+        vpds = [s[0] for s in sorted_by_vpd]
+        vels = [s[1] for s in sorted_by_vpd]
+        # Naive: ceiling = VPD at which velocity exceeds 1.5× median
+        median_v = statistics.median(vels)
+        ceiling = next((v for v, vel in sorted_by_vpd if vel > 1.5 * median_v), max(vpds))
+        cultivar = self._read_zone_cultivar(zone) or "unknown"
+        self.set_state(
+            f"sensor.crop_steering_cultivar_{cultivar}_vpd_ceiling_kpa",
+            state=round(ceiling, 2),
+            attributes={
+                "sample_count": len(samples),
+                "median_velocity_pct_per_hr": round(median_v, 3),
+                "unit_of_measurement": "kPa",
+                "friendly_name": f"VPD ceiling — {cultivar}",
+                "icon": "mdi:weather-windy",
+            },
+        )
+
+    # ------------------------------------------------------------------ Run report
+
+    def _emit_run_report(self, _kwargs: Any) -> None:
+        run_date = datetime.utcnow().date().isoformat()
+        report: dict[str, Any] = {"run_date": run_date, "zones": {}}
+        for zone in self._configured_zones():
+            shots = self.store.recent_shots(zone, hours=24)
+            report["zones"][zone] = {
+                "shot_count": len(shots),
+                "total_volume_ml": round(sum(s.get("volume_ml") or 0 for s in shots), 1),
+                "mean_runoff_pct": round(
+                    statistics.mean([s["runoff_pct"] for s in shots if s.get("runoff_pct") is not None] or [0.0]), 2
+                ),
+            }
+        self.store.write_run_report(run_date, report)
+        self.bus.publish("run.report", report)
+        self.fire_event("crop_steering_run_report", report=report)
+        self.log("Emitted run report for %s (%d zones)", run_date, len(report["zones"]))
+
+    # ------------------------------------------------------------------ helpers
+
+    def _read_float(self, entity_id: str | None, default: float | None = None) -> float | None:
+        if not entity_id:
+            return default
+        try:
+            return float(self.get_state(entity_id))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    def _read_zone_cultivar(self, zone: int) -> str | None:
+        return self.get_state(f"select.crop_steering_zone_{zone}_crop_type")  # type: ignore[return-value]
+
+    def _configured_zones(self) -> list[int]:
+        zones = []
+        for n in range(1, 25):
+            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
+                zones.append(n)
+        return zones
+
+    def entity_exists(self, entity_id: str) -> bool:
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/agronomic.py
+++ b/appdaemon/apps/crop_steering/intelligence/agronomic.py
@@ -17,14 +17,9 @@ import statistics
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any, Deque
 
-try:
-    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
-except ImportError:  # pragma: no cover
-    hass = type("hass", (), {"Hass": object})  # type: ignore
-
+from .base import IntelligenceApp
 from .bus import RootSenseBus
 from .store import RootSenseStore
 
@@ -39,11 +34,10 @@ class TranspirationSample:
     ppfd: float
 
 
-class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
+class AgronomicIntelligence(IntelligenceApp):
     def initialize(self) -> None:
         self.bus = RootSenseBus.instance()
-        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
-        self.store = RootSenseStore(db_path)
+        self.store = RootSenseStore(self._state_dir() / "rootsense.db")
 
         cfg = self.args or {}
         self.air_movement_m_s: float = float(cfg.get("room_air_movement_m_s", 0.3))
@@ -70,6 +64,8 @@ class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ Transpiration
 
     def _publish_transpiration(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         vpd = self._read_vpd_kpa()
         ppfd = self._read_float(self.ppfd_entity, default=0.0) if self.ppfd_entity else 0.0
         if vpd is None:
@@ -122,6 +118,8 @@ class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ Climate↔Substrate
 
     def _on_dryback_complete(self, _topic: str, payload: dict[str, Any]) -> None:
+        if not self._is_module_enabled():
+            return
         zone = int(payload.get("zone", 0))
         velocity = float(payload.get("slope_pct_h", 0.0))  # %/hour
         vpd_avg = float(payload.get("vpd_avg", 0.0))
@@ -157,6 +155,8 @@ class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ Run report
 
     def _emit_run_report(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         run_date = datetime.utcnow().date().isoformat()
         report: dict[str, Any] = {"run_date": run_date, "zones": {}}
         for zone in self._configured_zones():
@@ -176,25 +176,12 @@ class AgronomicIntelligence(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ helpers
 
     def _read_float(self, entity_id: str | None, default: float | None = None) -> float | None:
+        # Override of base helper — accepts None entity_id (returns default).
         if not entity_id:
             return default
-        try:
-            return float(self.get_state(entity_id))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return default
+        return super()._read_float(entity_id, default=default)
 
     def _read_zone_cultivar(self, zone: int) -> str | None:
         return self.get_state(f"select.crop_steering_zone_{zone}_crop_type")  # type: ignore[return-value]
 
-    def _configured_zones(self) -> list[int]:
-        zones = []
-        for n in range(1, 25):
-            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
-                zones.append(n)
-        return zones
-
-    def entity_exists(self, entity_id: str) -> bool:
-        try:
-            return super().entity_exists(entity_id)  # type: ignore[misc]
-        except AttributeError:
-            return self.get_state(entity_id) is not None
+    # _configured_zones / entity_exists live on IntelligenceApp.

--- a/appdaemon/apps/crop_steering/intelligence/anomaly.py
+++ b/appdaemon/apps/crop_steering/intelligence/anomaly.py
@@ -22,14 +22,9 @@ import logging
 import statistics
 from collections import defaultdict, deque
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any, Deque
 
-try:
-    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
-except ImportError:  # pragma: no cover
-    hass = type("hass", (), {"Hass": object})  # type: ignore
-
+from .base import IntelligenceApp
 from .bus import RootSenseBus
 from .store import RootSenseStore
 
@@ -71,11 +66,10 @@ REMEDIATION = {
 }
 
 
-class AnomalyScanner(hass.Hass):  # type: ignore[misc]
+class AnomalyScanner(IntelligenceApp):
     def initialize(self) -> None:
         self.bus = RootSenseBus.instance()
-        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
-        self.store = RootSenseStore(db_path)
+        self.store = RootSenseStore(self._state_dir() / "rootsense.db")
 
         cfg = self.args or {}
         self.scan_interval_s: int = int(cfg.get("scan_interval_s", 60))
@@ -99,6 +93,8 @@ class AnomalyScanner(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ event capture
 
     def _on_shot_response(self, _topic: str, payload: dict[str, Any]) -> None:
+        if not self._is_module_enabled():
+            return
         zone = int(payload["zone"])
         delta = float(payload.get("delta") or 0.0)
         if delta < 0.3:
@@ -125,6 +121,8 @@ class AnomalyScanner(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ periodic scan
 
     def _scan(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         zones = self._configured_zones()
         # Sample current state into buffers
         for z in zones:
@@ -261,21 +259,4 @@ class AnomalyScanner(hass.Hass):  # type: ignore[misc]
         state = self.get_state("binary_sensor.crop_steering_lights")
         return state == "on"
 
-    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
-        try:
-            return float(self.get_state(entity_id))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return default
-
-    def _configured_zones(self) -> list[int]:
-        zones = []
-        for n in range(1, 25):
-            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
-                zones.append(n)
-        return zones
-
-    def entity_exists(self, entity_id: str) -> bool:
-        try:
-            return super().entity_exists(entity_id)  # type: ignore[misc]
-        except AttributeError:
-            return self.get_state(entity_id) is not None
+    # _read_float / _configured_zones / entity_exists live on IntelligenceApp.

--- a/appdaemon/apps/crop_steering/intelligence/anomaly.py
+++ b/appdaemon/apps/crop_steering/intelligence/anomaly.py
@@ -1,0 +1,281 @@
+"""Cross-cutting anomaly detection for RootSense.
+
+Runs every 60 s. Per-zone rules + peer-comparison rules. Each anomaly:
+
+- is persisted to the analytics store,
+- is republished as `crop_steering_anomaly` HA event with severity + remediation,
+- toggles `binary_sensor.crop_steering_anomaly_active`.
+
+Codes (with default severity in parens):
+
+- emitter_blockage   (warning)  : repeated shots with negligible ΔVWC
+- ec_drift_high      (warning)  : 6h rolling EC > 1.3× target
+- vwc_flat_line      (warning)  : VWC stddev < 0.05% over 30 min during photoperiod
+- dryback_undetected (info)     : >4h since last detected peak during photoperiod
+- peer_vwc_deviation (warning)  : zone VWC > 2σ from peer mean for 15 min
+- peer_ec_deviation  (warning)  : zone EC > 2σ from peer mean for 30 min
+- valve_runtime      (critical) : valve on > max_runtime_sec (existing watchdog promoted)
+"""
+from __future__ import annotations
+
+import logging
+import statistics
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Deque
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+from .bus import RootSenseBus
+from .store import RootSenseStore
+
+_LOGGER = logging.getLogger(__name__)
+
+ANOMALY_BINARY_SENSOR = "binary_sensor.crop_steering_anomaly_active"
+
+REMEDIATION = {
+    "emitter_blockage": (
+        "1. Inspect the dripper line for kinks or biofilm.\n"
+        "2. Test emitter pressure with a test cup.\n"
+        "3. Run `crop_steering.custom_shot zone={zone} intent=test_emitter volume_ml=50`.\n"
+        "4. If ΔVWC remains <0.3% after a clean shot, replace the emitter."
+    ),
+    "ec_drift_high": (
+        "1. Check feed-tank EC vs target.\n"
+        "2. Verify dosing pump is calibrated.\n"
+        "3. Consider firing a flush shot via `crop_steering.custom_shot intent=rebalance_ec`."
+    ),
+    "vwc_flat_line": (
+        "1. Confirm sensor power and connector seating.\n"
+        "2. Check ESPHome / MQTT sensor status.\n"
+        "3. If both front and back sensors are flat, suspect cable break."
+    ),
+    "dryback_undetected": (
+        "1. Verify lights schedule and PPFD.\n"
+        "2. Check transpiration sensor for plausible value.\n"
+        "3. Inspect plant for wilting or root-zone hypoxia."
+    ),
+    "peer_vwc_deviation": (
+        "1. Compare flow rates across peer zones.\n"
+        "2. Check for stuck or partly open peer valves.\n"
+        "3. Inspect substrate moisture by hand on outlier zone."
+    ),
+    "peer_ec_deviation": (
+        "1. Verify per-zone EC sensor calibration.\n"
+        "2. Check if outlier zone receives mixed feed (e.g. shared manifold)."
+    ),
+}
+
+
+class AnomalyScanner(hass.Hass):  # type: ignore[misc]
+    def initialize(self) -> None:
+        self.bus = RootSenseBus.instance()
+        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
+        self.store = RootSenseStore(db_path)
+
+        cfg = self.args or {}
+        self.scan_interval_s: int = int(cfg.get("scan_interval_s", 60))
+        self.peer_groups: dict[str, list[int]] = cfg.get("peer_groups", {})  # name -> [zone IDs]
+
+        # Rolling buffers (60 samples per zone, expected 1/min ⇒ 1h)
+        self._vwc_buf: dict[int, Deque[tuple[datetime, float]]] = defaultdict(lambda: deque(maxlen=60))
+        self._ec_buf: dict[int, Deque[tuple[datetime, float]]] = defaultdict(lambda: deque(maxlen=360))  # 6h
+        self._last_dryback_ts: dict[int, datetime] = {}
+        self._consecutive_low_response_shots: dict[int, int] = defaultdict(int)
+        self._active_anomalies: set[str] = set()
+
+        # Track shot responses for emitter detection
+        self.bus.subscribe("shot.response", self._on_shot_response)
+        self.bus.subscribe("dryback.complete", self._on_dryback_complete)
+
+        self.run_every(self._scan, "now+10", self.scan_interval_s)
+        self.log("AnomalyScanner ready (scan=%ds, peer_groups=%s)",
+                 self.scan_interval_s, list(self.peer_groups))
+
+    # ------------------------------------------------------------------ event capture
+
+    def _on_shot_response(self, _topic: str, payload: dict[str, Any]) -> None:
+        zone = int(payload["zone"])
+        delta = float(payload.get("delta") or 0.0)
+        if delta < 0.3:
+            self._consecutive_low_response_shots[zone] += 1
+        else:
+            self._consecutive_low_response_shots[zone] = 0
+
+        if self._consecutive_low_response_shots[zone] >= 3:
+            self._raise(
+                code="emitter_blockage",
+                zone=zone,
+                severity="warning",
+                evidence=(
+                    f"3 consecutive shots produced <0.3%% ΔVWC "
+                    f"(latest pre={payload.get('pre_vwc')}, peak={payload.get('peak_vwc')})."
+                ),
+            )
+
+    def _on_dryback_complete(self, _topic: str, payload: dict[str, Any]) -> None:
+        zone = int(payload["zone"])
+        self._last_dryback_ts[zone] = datetime.utcnow()
+        self._clear("dryback_undetected", zone)
+
+    # ------------------------------------------------------------------ periodic scan
+
+    def _scan(self, _kwargs: Any) -> None:
+        zones = self._configured_zones()
+        # Sample current state into buffers
+        for z in zones:
+            vwc = self._read_float(f"sensor.crop_steering_zone_{z}_avg_vwc")
+            ec = self._read_float(f"sensor.crop_steering_zone_{z}_avg_ec")
+            now = datetime.utcnow()
+            if vwc is not None:
+                self._vwc_buf[z].append((now, vwc))
+            if ec is not None:
+                self._ec_buf[z].append((now, ec))
+
+        # Per-zone rules
+        for z in zones:
+            self._check_vwc_flat_line(z)
+            self._check_ec_drift_high(z)
+            self._check_dryback_undetected(z)
+
+        # Peer rules
+        for group_name, group_zones in self.peer_groups.items():
+            self._check_peer_deviation(group_name, group_zones)
+
+        # Update aggregate binary sensor
+        self.set_state(
+            ANOMALY_BINARY_SENSOR,
+            state="on" if self._active_anomalies else "off",
+            attributes={
+                "active_count": len(self._active_anomalies),
+                "active_codes": sorted(self._active_anomalies),
+                "friendly_name": "Crop Steering Anomaly Active",
+                "device_class": "problem",
+            },
+        )
+
+    # ------------------------------------------------------------------ rules
+
+    def _check_vwc_flat_line(self, zone: int) -> None:
+        if not self._is_photoperiod():
+            return
+        recent = [v for ts, v in self._vwc_buf[zone] if datetime.utcnow() - ts <= timedelta(minutes=30)]
+        if len(recent) < 10:
+            return
+        if statistics.pstdev(recent) < 0.05:
+            self._raise(
+                code="vwc_flat_line",
+                zone=zone,
+                severity="warning",
+                evidence=f"VWC stddev over last 30 min = {statistics.pstdev(recent):.3f}% (threshold 0.05).",
+            )
+        else:
+            self._clear("vwc_flat_line", zone)
+
+    def _check_ec_drift_high(self, zone: int) -> None:
+        recent = [e for ts, e in self._ec_buf[zone] if datetime.utcnow() - ts <= timedelta(hours=6)]
+        target = self._read_float(f"number.crop_steering_zone_{zone}_ec_target") or 0
+        if not recent or target <= 0:
+            return
+        mean_ec = statistics.mean(recent)
+        if mean_ec > 1.3 * target:
+            self._raise(
+                code="ec_drift_high",
+                zone=zone,
+                severity="warning",
+                evidence=f"6h mean EC = {mean_ec:.2f} mS/cm vs target {target:.2f} (×{mean_ec/target:.2f}).",
+            )
+        else:
+            self._clear("ec_drift_high", zone)
+
+    def _check_dryback_undetected(self, zone: int) -> None:
+        if not self._is_photoperiod():
+            return
+        last = self._last_dryback_ts.get(zone)
+        if last and datetime.utcnow() - last <= timedelta(hours=4):
+            return
+        if last is None:
+            return  # too early
+        self._raise(
+            code="dryback_undetected",
+            zone=zone,
+            severity="info",
+            evidence=f"No dryback peak detected for {(datetime.utcnow() - last).total_seconds() / 3600:.1f}h.",
+        )
+
+    def _check_peer_deviation(self, group: str, zones: list[int]) -> None:
+        readings = []
+        for z in zones:
+            v = self._read_float(f"sensor.crop_steering_zone_{z}_avg_vwc")
+            if v is not None:
+                readings.append((z, v))
+        if len(readings) < 3:
+            return
+        values = [v for _, v in readings]
+        mean = statistics.mean(values)
+        stdev = statistics.pstdev(values) or 1e-6
+        for z, v in readings:
+            if abs(v - mean) > 2 * stdev:
+                self._raise(
+                    code="peer_vwc_deviation",
+                    zone=z,
+                    severity="warning",
+                    evidence=(f"Zone {z} VWC={v:.2f}% deviates from peer group "
+                              f"'{group}' (mean={mean:.2f}, σ={stdev:.2f})."),
+                )
+            else:
+                self._clear("peer_vwc_deviation", z)
+
+    # ------------------------------------------------------------------ helpers
+
+    def _raise(self, *, code: str, zone: int | None, severity: str, evidence: str) -> None:
+        key = f"{code}:{zone}" if zone is not None else code
+        if key in self._active_anomalies:
+            return  # already raised, don't spam
+        self._active_anomalies.add(key)
+        remediation = REMEDIATION.get(code, "See dashboard.").format(zone=zone)
+        ts = datetime.utcnow().isoformat()
+        self.store.record_anomaly(
+            ts=ts, zone=zone, code=code, severity=severity,
+            evidence=evidence, remediation=remediation,
+        )
+        self.bus.publish("anomaly.detected", {
+            "code": code, "zone": zone, "severity": severity,
+            "evidence": evidence, "remediation": remediation, "ts": ts,
+        })
+        self.fire_event("crop_steering_anomaly",
+                        code=code, zone=zone, severity=severity,
+                        evidence=evidence, remediation=remediation, ts=ts)
+        self.log("ANOMALY [%s] zone=%s %s — %s", severity, zone, code, evidence,
+                 level="WARNING" if severity != "info" else "INFO")
+
+    def _clear(self, code: str, zone: int) -> None:
+        key = f"{code}:{zone}"
+        self._active_anomalies.discard(key)
+
+    def _is_photoperiod(self) -> bool:
+        state = self.get_state("binary_sensor.crop_steering_lights")
+        return state == "on"
+
+    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
+        try:
+            return float(self.get_state(entity_id))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    def _configured_zones(self) -> list[int]:
+        zones = []
+        for n in range(1, 25):
+            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
+                zones.append(n)
+        return zones
+
+    def entity_exists(self, entity_id: str) -> bool:
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/base.py
+++ b/appdaemon/apps/crop_steering/intelligence/base.py
@@ -1,0 +1,99 @@
+"""Shared base for RootSense intelligence apps.
+
+Provides:
+- module-enable switch gating (`_is_module_enabled`)
+- common `_read_float` / `_configured_zones` helpers used by every pillar
+- a uniform `app_state_dir` resolution so the SQLite store always lives at
+  appdaemon/apps/crop_steering/state/rootsense.db regardless of how the
+  hosting AppDaemon container mounts paths.
+
+Every pillar app inherits from `IntelligenceApp` instead of `hass.Hass`
+directly. Pillars stay independently enableable: if the switch is OFF the
+periodic loops short-circuit before doing any work.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Map app class name → switch entity that gates it.
+MODULE_SWITCH = {
+    "RootZoneIntelligence":   "switch.crop_steering_intelligence_root_zone_enabled",
+    "AdaptiveIrrigation":     "switch.crop_steering_intelligence_adaptive_enabled",
+    "AgronomicIntelligence":  "switch.crop_steering_intelligence_agronomic_enabled",
+    "IrrigationOrchestrator": "switch.crop_steering_intelligence_orchestrator_enabled",
+    "AnomalyScanner":         "switch.crop_steering_intelligence_anomaly_enabled",
+}
+
+
+class IntelligenceApp(hass.Hass):  # type: ignore[misc]
+    """Mixin-style base for the five intelligence pillars.
+
+    Subclasses should still define their own ``initialize()`` — they call
+    ``super().initialize()`` (or just ignore this base if they need full
+    control). The helper methods below are available on every subclass.
+    """
+
+    # ------------------------------------------------------------------ gating
+
+    def _is_module_enabled(self) -> bool:
+        """Return True if this pillar's enable switch is on (or missing)."""
+        switch = MODULE_SWITCH.get(type(self).__name__)
+        if switch is None:
+            return True  # unknown class — fail-open during development
+        try:
+            state = self.get_state(switch)
+        except Exception:  # noqa: BLE001
+            return True
+        if state is None:
+            # entity hasn't been created yet (fresh install before integration
+            # reload) — default to ENABLED so the operator's first reload
+            # doesn't silently skip everything. Subsequent runs find the
+            # switch and respect its actual state.
+            return True
+        return str(state).lower() == "on"
+
+    # ------------------------------------------------------------------ paths
+
+    def _state_dir(self) -> Path:
+        """Resolve the rootsense.db directory under appdaemon/apps/.../state/."""
+        base = Path(self.app_dir) / "crop_steering" / "state"
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    # ------------------------------------------------------------------ reads
+
+    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
+        try:
+            return float(self.get_state(entity_id))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    def _read_int(self, entity_id: str, default: int | None = None) -> int | None:
+        try:
+            return int(float(self.get_state(entity_id)))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    def _configured_zones(self) -> list[int]:
+        """Return zone IDs that have a `..._avg_vwc` sensor in HA."""
+        zones: list[int] = []
+        for n in range(1, 25):
+            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
+                zones.append(n)
+        return zones
+
+    # ------------------------------------------------------------------ shims
+
+    def entity_exists(self, entity_id: str) -> bool:
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/bus.py
+++ b/appdaemon/apps/crop_steering/intelligence/bus.py
@@ -1,0 +1,76 @@
+"""In-process pub/sub bus for RootSense intelligence modules.
+
+Why a separate bus rather than reusing AppDaemon's event system:
+
+- Some payloads are large (full dryback episodes, optimisation posteriors)
+  and not interesting to HA — keeping them in-process avoids round-trips
+  through the HA event bus.
+- Subscribers can be plain Python callables on the AppDaemon side without
+  needing `listen_event` plumbing.
+- HA still receives the high-signal events (anomalies, run reports, custom
+  shots) via the orchestration coordinator's bridge.
+
+Usage::
+
+    bus = RootSenseBus.instance()
+    bus.subscribe("dryback.complete", my_callback)
+    bus.publish("dryback.complete", {"zone": 1, "pct": 18.4})
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict
+
+_LOGGER = logging.getLogger(__name__)
+
+Handler = Callable[[str, dict[str, Any]], None]
+
+
+class RootSenseBus:
+    _singleton: "RootSenseBus | None" = None
+    _singleton_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._subs: DefaultDict[str, list[Handler]] = defaultdict(list)
+        self._lock = threading.RLock()
+
+    @classmethod
+    def instance(cls) -> "RootSenseBus":
+        if cls._singleton is None:
+            with cls._singleton_lock:
+                if cls._singleton is None:
+                    cls._singleton = cls()
+        return cls._singleton
+
+    def subscribe(self, topic: str, handler: Handler) -> None:
+        with self._lock:
+            self._subs[topic].append(handler)
+        _LOGGER.debug("RootSenseBus: %s subscribed to %s", handler, topic)
+
+    def unsubscribe(self, topic: str, handler: Handler) -> None:
+        with self._lock:
+            if handler in self._subs.get(topic, []):
+                self._subs[topic].remove(handler)
+
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        with self._lock:
+            handlers = list(self._subs.get(topic, []))
+        for h in handlers:
+            try:
+                h(topic, payload)
+            except Exception:  # noqa: BLE001 — pub/sub must not crash producers
+                _LOGGER.exception("RootSenseBus handler failed on %s", topic)
+
+
+TOPICS = {
+    "shot.requested": "An intelligence module wants a shot fired.",
+    "shot.fired": "Hardware confirmed a shot was executed.",
+    "shot.response": "Post-shot VWC peak observed; payload includes ΔVWC.",
+    "dryback.complete": "A full dryback episode (peak → valley) was detected.",
+    "field_capacity.observed": "FieldCapacityObserver published a new estimate.",
+    "intent.changed": "Cultivator intent slider moved; derived params re-published.",
+    "anomaly.detected": "AnomalyScanner flagged something worth surfacing.",
+    "run.report": "Nightly run report ready.",
+}

--- a/appdaemon/apps/crop_steering/intelligence/orchestration.py
+++ b/appdaemon/apps/crop_steering/intelligence/orchestration.py
@@ -1,0 +1,213 @@
+"""Pillar 4 — Irrigation Orchestration.
+
+The Coordinator is the only module allowed to send service calls that
+result in hardware action. Every other intelligence module proposes;
+the coordinator arbitrates.
+
+Responsibilities:
+
+- Subscribe to RootSenseBus topics that produce shot proposals.
+- Apply safety gates (anomaly suppression, manual-override respect,
+  emergency cooldown) before forwarding to the hardware layer.
+- Implement the new `crop_steering.custom_shot` HA service.
+- Implement emergency / flush logic with the new guardrails.
+- Publish `binary_sensor.crop_steering_anomaly_active`.
+
+This file is a runnable AppDaemon app.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+from .bus import RootSenseBus
+from .store import RootSenseStore
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_FLUSH_COOLDOWN_MIN = 240  # 4 hours
+DEFAULT_EMERGENCY_VWC_PCT = 40.0
+
+
+class IrrigationOrchestrator(hass.Hass):  # type: ignore[misc]
+    def initialize(self) -> None:
+        self.bus = RootSenseBus.instance()
+        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
+        self.store = RootSenseStore(db_path)
+
+        cfg = self.args or {}
+        self.flush_cooldown = timedelta(minutes=int(cfg.get("flush_cooldown_min", DEFAULT_FLUSH_COOLDOWN_MIN)))
+        self.emergency_vwc = float(cfg.get("emergency_vwc_pct", DEFAULT_EMERGENCY_VWC_PCT))
+
+        self._last_flush_at: dict[int, datetime] = {}
+        self._suppressed_zones: set[int] = set()
+
+        # HA service: custom shot
+        self.register_service("crop_steering/custom_shot", self._on_custom_shot_service)
+
+        # Bus subscriptions
+        self.bus.subscribe("anomaly.detected", self._on_anomaly)
+        self.bus.subscribe("shot.requested", self._on_shot_requested)
+
+        # Periodic emergency check (every 30 s)
+        self.run_every(self._emergency_check, "now+30", 30)
+
+        self.log("IrrigationOrchestrator ready")
+
+    # ------------------------------------------------------------------ services
+
+    async def _on_custom_shot_service(self, namespace, domain, service, kwargs):  # noqa: D401
+        # AppDaemon service signature; payload comes via kwargs["data"].
+        data = kwargs.get("data", {}) or kwargs
+        zone = int(data.get("target_zone", 0))
+        if zone <= 0:
+            self.log("custom_shot ignored: invalid zone %s", zone, level="WARNING")
+            return
+        intent_label = data.get("intent", "manual")
+        volume_ml = float(data.get("volume_ml", 0))
+        target_runoff_pct = data.get("target_runoff_pct")
+        tag = data.get("tag", "operator")
+
+        if zone in self._suppressed_zones:
+            self.log("custom_shot suppressed for zone %s (anomaly-active)", zone, level="WARNING")
+            return
+
+        # Convert volume to duration via flow-rate number entity
+        flow_rate_lpm = self._read_flow_rate_lpm(zone)
+        if flow_rate_lpm <= 0:
+            self.log("custom_shot zone %s: flow rate unknown, aborting", zone, level="ERROR")
+            return
+        duration_s = max(1.0, (volume_ml / 1000.0) / flow_rate_lpm * 60.0)
+
+        # Persist intent
+        self.store.record_shot(
+            ts=datetime.utcnow().isoformat(),
+            zone=zone,
+            phase=self.get_state("select.crop_steering_irrigation_phase"),
+            shot_type="custom",
+            intent=self._read_intent(),
+            volume_ml=volume_ml,
+            duration_s=duration_s,
+            vwc_before=self._read_zone_vwc(zone),
+            tag=f"{intent_label}:{tag}",
+        )
+
+        # Hand off to legacy service (which talks to hardware)
+        await self.call_service(
+            "crop_steering/execute_irrigation_shot",
+            zone=zone,
+            duration_seconds=int(duration_s),
+            shot_type="custom",
+        )
+        self.log("custom_shot fired: zone=%s vol=%.1fmL dur=%.1fs intent=%s tag=%s",
+                 zone, volume_ml, duration_s, intent_label, tag)
+
+    # ------------------------------------------------------------------ bus handlers
+
+    def _on_shot_requested(self, _topic: str, payload: dict[str, Any]) -> None:
+        # Forward intelligence-module proposals through the same gate as a
+        # custom shot. ShotPlanner builds the payload in the right shape.
+        self.fire_event("crop_steering_shot_proposal", **payload)
+        # Use the service path so logging/safety stay unified.
+        self.run_in(self._fire_proposal, 0, payload=payload)
+
+    def _fire_proposal(self, kwargs: dict[str, Any]) -> None:
+        payload = kwargs["payload"]
+        self.call_service("crop_steering/custom_shot", **payload)
+
+    def _on_anomaly(self, _topic: str, payload: dict[str, Any]) -> None:
+        zone = payload.get("zone")
+        severity = payload.get("severity", "info")
+        if severity == "critical" and isinstance(zone, int):
+            self._suppressed_zones.add(zone)
+            self.log("Zone %s suppressed due to critical anomaly: %s", zone, payload.get("code"),
+                     level="WARNING")
+        # binary_sensor.crop_steering_anomaly_active toggling lives in anomaly.py
+
+    # ------------------------------------------------------------------ emergency / flush
+
+    def _emergency_check(self, _kwargs: Any) -> None:
+        for zone in self._configured_zones():
+            vwc = self._read_zone_vwc(zone)
+            if vwc is None:
+                continue
+            if vwc < self.emergency_vwc and zone not in self._suppressed_zones:
+                self._fire_emergency_rescue(zone, vwc)
+            self._maybe_fire_flush(zone)
+
+    def _fire_emergency_rescue(self, zone: int, vwc: float) -> None:
+        # Conservative: 2% shot of substrate volume.
+        substrate_l = self._read_substrate_volume_l(zone)
+        volume_ml = max(50.0, substrate_l * 20.0)  # 2% of L → mL
+        self.log("EMERGENCY rescue: zone %s VWC=%.1f%% < %.1f%%; firing %.1fmL",
+                 zone, vwc, self.emergency_vwc, volume_ml, level="WARNING")
+        self.call_service(
+            "crop_steering/custom_shot",
+            target_zone=zone,
+            intent="rescue",
+            volume_ml=volume_ml,
+            tag=f"emergency:vwc={vwc:.1f}",
+        )
+
+    def _maybe_fire_flush(self, zone: int) -> None:
+        ec_runoff = self._read_float(f"sensor.crop_steering_zone_{zone}_ec_runoff")
+        ec_feed = self._read_float(f"sensor.crop_steering_zone_{zone}_ec_feed")
+        if ec_runoff is None or ec_feed is None or ec_feed <= 0:
+            return
+        if ec_runoff < 1.5 * ec_feed:
+            return
+        last = self._last_flush_at.get(zone)
+        if last and datetime.utcnow() - last < self.flush_cooldown:
+            return
+        substrate_l = self._read_substrate_volume_l(zone)
+        volume_ml = substrate_l * 100.0  # 10% of substrate volume
+        self.log("Flush shot: zone %s ec_runoff/ec_feed=%.2f → %.1fmL",
+                 zone, ec_runoff / ec_feed, volume_ml, level="WARNING")
+        self.call_service(
+            "crop_steering/custom_shot",
+            target_zone=zone,
+            intent="rebalance_ec",
+            volume_ml=volume_ml,
+            tag=f"flush:ec_ratio={ec_runoff / ec_feed:.2f}",
+        )
+        self._last_flush_at[zone] = datetime.utcnow()
+
+    # ------------------------------------------------------------------ helpers
+
+    def _read_zone_vwc(self, zone: int) -> float | None:
+        return self._read_float(f"sensor.crop_steering_zone_{zone}_avg_vwc")
+
+    def _read_flow_rate_lpm(self, zone: int) -> float:
+        return self._read_float(f"number.crop_steering_zone_{zone}_dripper_flow_rate", default=2.0) or 2.0
+
+    def _read_substrate_volume_l(self, zone: int) -> float:
+        return self._read_float(f"number.crop_steering_zone_{zone}_substrate_size", default=10.0) or 10.0
+
+    def _read_intent(self) -> float:
+        return self._read_float("number.crop_steering_steering_intent", default=0.0) or 0.0
+
+    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
+        try:
+            return float(self.get_state(entity_id))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return default
+
+    def _configured_zones(self) -> list[int]:
+        zones = []
+        for n in range(1, 25):
+            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
+                zones.append(n)
+        return zones
+
+    def entity_exists(self, entity_id: str) -> bool:
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/orchestration.py
+++ b/appdaemon/apps/crop_steering/intelligence/orchestration.py
@@ -19,14 +19,9 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any
 
-try:
-    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
-except ImportError:  # pragma: no cover
-    hass = type("hass", (), {"Hass": object})  # type: ignore
-
+from .base import IntelligenceApp
 from .bus import RootSenseBus
 from .store import RootSenseStore
 
@@ -36,11 +31,10 @@ DEFAULT_FLUSH_COOLDOWN_MIN = 240  # 4 hours
 DEFAULT_EMERGENCY_VWC_PCT = 40.0
 
 
-class IrrigationOrchestrator(hass.Hass):  # type: ignore[misc]
+class IrrigationOrchestrator(IntelligenceApp):
     def initialize(self) -> None:
         self.bus = RootSenseBus.instance()
-        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
-        self.store = RootSenseStore(db_path)
+        self.store = RootSenseStore(self._state_dir() / "rootsense.db")
 
         cfg = self.args or {}
         self.flush_cooldown = timedelta(minutes=int(cfg.get("flush_cooldown_min", DEFAULT_FLUSH_COOLDOWN_MIN)))
@@ -65,6 +59,9 @@ class IrrigationOrchestrator(hass.Hass):  # type: ignore[misc]
 
     async def _on_custom_shot_service(self, namespace, domain, service, kwargs):  # noqa: D401
         # AppDaemon service signature; payload comes via kwargs["data"].
+        if not self._is_module_enabled():
+            self.log("custom_shot ignored: orchestrator module disabled", level="WARNING")
+            return
         data = kwargs.get("data", {}) or kwargs
         zone = int(data.get("target_zone", 0))
         if zone <= 0:
@@ -134,6 +131,8 @@ class IrrigationOrchestrator(hass.Hass):  # type: ignore[misc]
     # ------------------------------------------------------------------ emergency / flush
 
     def _emergency_check(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         for zone in self._configured_zones():
             vwc = self._read_zone_vwc(zone)
             if vwc is None:
@@ -193,21 +192,4 @@ class IrrigationOrchestrator(hass.Hass):  # type: ignore[misc]
     def _read_intent(self) -> float:
         return self._read_float("number.crop_steering_steering_intent", default=0.0) or 0.0
 
-    def _read_float(self, entity_id: str, default: float | None = None) -> float | None:
-        try:
-            return float(self.get_state(entity_id))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return default
-
-    def _configured_zones(self) -> list[int]:
-        zones = []
-        for n in range(1, 25):
-            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
-                zones.append(n)
-        return zones
-
-    def entity_exists(self, entity_id: str) -> bool:
-        try:
-            return super().entity_exists(entity_id)  # type: ignore[misc]
-        except AttributeError:
-            return self.get_state(entity_id) is not None
+    # _read_float / _configured_zones / entity_exists live on IntelligenceApp.

--- a/appdaemon/apps/crop_steering/intelligence/root_zone.py
+++ b/appdaemon/apps/crop_steering/intelligence/root_zone.py
@@ -1,0 +1,258 @@
+"""Pillar 1 — Root Zone Intelligence.
+
+Substrate analytics, automated field-capacity detection, dryback tracking.
+
+This file is a runnable AppDaemon app. It registers with the master app via
+`RootSenseBus`, listens for shot events, and publishes:
+
+- `sensor.crop_steering_zone_{n}_field_capacity_observed`
+- `sensor.crop_steering_zone_{n}_dryback_velocity_pct_per_hr`
+- `sensor.crop_steering_zone_{n}_substrate_porosity_estimate`
+- `sensor.crop_steering_zone_{n}_ec_stack_index`
+
+Plus events:
+- `crop_steering_dryback_complete`
+- `crop_steering_field_capacity_observed`
+
+Behaviour summary (see ROOTSENSE_v3_PLAN.md §3 Phase 1 for full design):
+
+1. On every `crop_steering_irrigation_shot` event, snapshot pre-shot VWC.
+2. Wait `shot_response_window_sec` (default 600 s) and capture the post-shot
+   peak VWC for that zone.
+3. If two successive shots produce <0.5 % additional rise, declare the zone
+   saturated; the peak becomes a candidate FC observation.
+4. Maintain an EWMA per (zone, cultivar). Confidence ≥ 0.8 ⇒ controller uses
+   observed FC instead of the static `DEFAULT_FIELD_CAPACITY`.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Deque
+
+try:
+    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+except ImportError:  # pragma: no cover — keeps the module importable in tests
+    hass = type("hass", (), {"Hass": object})  # type: ignore
+
+from .bus import RootSenseBus
+from .store import RootSenseStore
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_RESPONSE_WINDOW_SEC = 600
+DEFAULT_SATURATION_DELTA_PCT = 0.5      # < this rise on consecutive shots ⇒ saturated
+DEFAULT_FC_EWMA_ALPHA = 0.25
+DEFAULT_FC_CONFIDENCE_THRESHOLD = 0.8
+
+
+@dataclass
+class ShotResponse:
+    zone: int
+    pre_vwc: float
+    fired_at: datetime
+    peak_vwc: float | None = None
+    peak_at: datetime | None = None
+
+    @property
+    def delta(self) -> float | None:
+        return None if self.peak_vwc is None else self.peak_vwc - self.pre_vwc
+
+
+@dataclass
+class FieldCapacityState:
+    fc_pct: float = 0.0
+    confidence: float = 0.0
+    sample_count: int = 0
+    history: Deque[float] = field(default_factory=lambda: deque(maxlen=20))
+
+
+class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
+    """AppDaemon entry point."""
+
+    def initialize(self) -> None:  # noqa: D401 — AppDaemon contract
+        self.bus = RootSenseBus.instance()
+        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
+        self.store = RootSenseStore(db_path)
+
+        cfg = self.args or {}
+        self.response_window_sec: int = int(cfg.get("response_window_sec", DEFAULT_RESPONSE_WINDOW_SEC))
+        self.saturation_delta_pct: float = float(cfg.get("saturation_delta_pct", DEFAULT_SATURATION_DELTA_PCT))
+        self.fc_alpha: float = float(cfg.get("fc_ewma_alpha", DEFAULT_FC_EWMA_ALPHA))
+        self.fc_confidence_threshold: float = float(
+            cfg.get("fc_confidence_threshold", DEFAULT_FC_CONFIDENCE_THRESHOLD)
+        )
+
+        self._pending: dict[int, ShotResponse] = {}
+        self._fc: dict[int, FieldCapacityState] = defaultdict(FieldCapacityState)
+
+        # Bridge HA event bus into RootSenseBus
+        self.listen_event(self._on_shot_fired, "crop_steering_irrigation_shot")
+
+        # Periodic publication of derived sensors (decoupled from shot rate)
+        self.run_every(self._publish_derived_sensors, "now+30", 60)
+
+        # Daily prune
+        self.run_daily(self._daily_prune, "03:30:00")
+
+        self.log("RootZoneIntelligence ready (window=%ds, sat-Δ=%.2f%%)",
+                 self.response_window_sec, self.saturation_delta_pct)
+
+    # ------------------------------------------------------------------ events
+
+    def _on_shot_fired(self, event_name: str, data: dict[str, Any], _kwargs: Any) -> None:
+        zone = int(data.get("zone", 0))
+        if zone <= 0:
+            return
+        pre_vwc = self._read_zone_vwc(zone)
+        if pre_vwc is None:
+            self.log("Skipping shot response capture for zone %s: VWC unavailable", zone)
+            return
+        self._pending[zone] = ShotResponse(zone=zone, pre_vwc=pre_vwc, fired_at=datetime.utcnow())
+        self.run_in(self._capture_peak, self.response_window_sec, zone=zone)
+
+    def _capture_peak(self, kwargs: dict[str, Any]) -> None:
+        zone = kwargs["zone"]
+        record = self._pending.pop(zone, None)
+        if record is None:
+            return
+        peak_vwc = self._read_zone_vwc_peak_since(zone, record.fired_at)
+        if peak_vwc is None:
+            return
+        record.peak_vwc = peak_vwc
+        record.peak_at = datetime.utcnow()
+
+        self.bus.publish("shot.response", {
+            "zone": zone,
+            "pre_vwc": record.pre_vwc,
+            "peak_vwc": peak_vwc,
+            "delta": record.delta,
+            "fired_at": record.fired_at.isoformat(),
+        })
+
+        self._update_field_capacity(record)
+
+    # ------------------------------------------------------------------ field capacity
+
+    def _update_field_capacity(self, record: ShotResponse) -> None:
+        zone = record.zone
+        fc = self._fc[zone]
+        fc.history.append(record.peak_vwc or 0.0)
+
+        if len(fc.history) < 2:
+            return
+        last_two = list(fc.history)[-2:]
+        rise_between_shots = last_two[1] - last_two[0]
+        if rise_between_shots > self.saturation_delta_pct:
+            return  # not yet saturated
+
+        observed_fc = last_two[1]
+        # EWMA
+        if fc.sample_count == 0:
+            fc.fc_pct = observed_fc
+        else:
+            fc.fc_pct = self.fc_alpha * observed_fc + (1 - self.fc_alpha) * fc.fc_pct
+        fc.sample_count += 1
+        fc.confidence = min(1.0, fc.sample_count / 5.0)
+
+        cultivar = self._read_zone_cultivar(zone)
+        self.store.record_field_capacity(
+            ts=datetime.utcnow().isoformat(),
+            zone=zone,
+            cultivar=cultivar,
+            fc_pct=fc.fc_pct,
+            confidence=fc.confidence,
+            sample_count=fc.sample_count,
+        )
+
+        self._publish_fc_sensor(zone, fc)
+        self.bus.publish("field_capacity.observed", {
+            "zone": zone,
+            "fc_pct": fc.fc_pct,
+            "confidence": fc.confidence,
+            "sample_count": fc.sample_count,
+            "cultivar": cultivar,
+        })
+        self.fire_event("crop_steering_field_capacity_observed", **{
+            "zone": zone,
+            "fc_pct": round(fc.fc_pct, 2),
+            "confidence": round(fc.confidence, 2),
+        })
+
+    # ------------------------------------------------------------------ derived sensors
+
+    def _publish_derived_sensors(self, _kwargs: Any) -> None:
+        for zone in self._configured_zones():
+            self._publish_dryback_velocity(zone)
+            self._publish_porosity_estimate(zone)
+            self._publish_ec_stack_index(zone)
+
+    def _publish_fc_sensor(self, zone: int, fc: FieldCapacityState) -> None:
+        self.set_state(
+            f"sensor.crop_steering_zone_{zone}_field_capacity_observed",
+            state=round(fc.fc_pct, 2),
+            attributes={
+                "confidence": round(fc.confidence, 3),
+                "sample_count": fc.sample_count,
+                "unit_of_measurement": "%",
+                "friendly_name": f"Zone {zone} Observed Field Capacity",
+                "icon": "mdi:water-percent",
+            },
+        )
+
+    def _publish_dryback_velocity(self, zone: int) -> None:
+        # Stub: real implementation reads the existing AdvancedDrybackDetector's
+        # rolling dryback rate. Placeholder publishes "unknown" until wired.
+        pass
+
+    def _publish_porosity_estimate(self, zone: int) -> None:
+        # Stub: porosity ≈ ΔVWC per mL applied; computed from `shots` table.
+        pass
+
+    def _publish_ec_stack_index(self, zone: int) -> None:
+        # Stub: cumulative (ec_runoff - ec_feed) integral over a window.
+        pass
+
+    # ------------------------------------------------------------------ helpers
+
+    def _read_zone_vwc(self, zone: int) -> float | None:
+        state = self.get_state(f"sensor.crop_steering_zone_{zone}_avg_vwc")
+        try:
+            return float(state)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+
+    def _read_zone_vwc_peak_since(self, zone: int, since: datetime) -> float | None:
+        # AppDaemon doesn't expose history directly; the master app maintains
+        # rolling buffers. For now, just sample current VWC — wired to the
+        # real buffer in PR #2.
+        return self._read_zone_vwc(zone)
+
+    def _read_zone_cultivar(self, zone: int) -> str | None:
+        return self.get_state(f"select.crop_steering_zone_{zone}_crop_type")  # type: ignore[return-value]
+
+    def _configured_zones(self) -> list[int]:
+        # Cheap discovery: scan for state.crop_steering_zone_{n}_avg_vwc for n in 1..24
+        zones = []
+        for n in range(1, 25):
+            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
+                zones.append(n)
+        return zones
+
+    def _daily_prune(self, _kwargs: Any) -> None:
+        try:
+            self.store.prune()
+        except Exception:  # noqa: BLE001
+            self.log("Daily prune failed", level="ERROR")
+
+    # ------------------------------------------------------------------ AppDaemon shims
+
+    def entity_exists(self, entity_id: str) -> bool:
+        # AppDaemon ≥4.4 has self.entity_exists; shim for older versions.
+        try:
+            return super().entity_exists(entity_id)  # type: ignore[misc]
+        except AttributeError:
+            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/root_zone.py
+++ b/appdaemon/apps/crop_steering/intelligence/root_zone.py
@@ -7,7 +7,7 @@ This file is a runnable AppDaemon app. It registers with the master app via
 
 - `sensor.crop_steering_zone_{n}_field_capacity_observed`
 - `sensor.crop_steering_zone_{n}_dryback_velocity_pct_per_hr`
-- `sensor.crop_steering_zone_{n}_substrate_porosity_estimate`
+- `sensor.crop_steering_zone_{n}_substrate_porosity_estimate_ml_per_pct`
 - `sensor.crop_steering_zone_{n}_ec_stack_index`
 
 Plus events:
@@ -23,6 +23,9 @@ Behaviour summary (see ROOTSENSE_v3_PLAN.md §3 Phase 1 for full design):
    saturated; the peak becomes a candidate FC observation.
 4. Maintain an EWMA per (zone, cultivar). Confidence ≥ 0.8 ⇒ controller uses
    observed FC instead of the static `DEFAULT_FIELD_CAPACITY`.
+5. Independently, sample VWC + EC every 60 s into a per-zone rolling buffer
+   used to detect dryback episodes (peak → valley) locally and publish the
+   three derived analytics sensors.
 """
 from __future__ import annotations
 
@@ -30,14 +33,9 @@ import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any, Deque
 
-try:
-    import appdaemon.plugins.hass.hassapi as hass  # type: ignore
-except ImportError:  # pragma: no cover — keeps the module importable in tests
-    hass = type("hass", (), {"Hass": object})  # type: ignore
-
+from .base import IntelligenceApp
 from .bus import RootSenseBus
 from .store import RootSenseStore
 
@@ -47,6 +45,10 @@ DEFAULT_RESPONSE_WINDOW_SEC = 600
 DEFAULT_SATURATION_DELTA_PCT = 0.5      # < this rise on consecutive shots ⇒ saturated
 DEFAULT_FC_EWMA_ALPHA = 0.25
 DEFAULT_FC_CONFIDENCE_THRESHOLD = 0.8
+DEFAULT_SAMPLE_INTERVAL_SEC = 60
+DEFAULT_BUFFER_HOURS = 24
+DEFAULT_DRYBACK_MIN_DROP_PCT = 1.0      # ignore micro-fluctuations
+DEFAULT_DRYBACK_MIN_DURATION_MIN = 15   # peak must hold for at least this long
 
 
 @dataclass
@@ -54,11 +56,13 @@ class ShotResponse:
     zone: int
     pre_vwc: float
     fired_at: datetime
+    pre_ec: float | None = None
+    volume_ml: float | None = None
     peak_vwc: float | None = None
     peak_at: datetime | None = None
 
     @property
-    def delta(self) -> float | None:
+    def delta_vwc(self) -> float | None:
         return None if self.peak_vwc is None else self.peak_vwc - self.pre_vwc
 
 
@@ -70,13 +74,29 @@ class FieldCapacityState:
     history: Deque[float] = field(default_factory=lambda: deque(maxlen=20))
 
 
-class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
+@dataclass
+class DrybackTracker:
+    """Per-zone running peak/valley tracker.
+
+    A peak is a local max in the VWC buffer. We then track valley (the
+    minimum since the peak) and emit a `DrybackEpisode` when a *new* peak
+    starts forming, i.e. VWC rises again from the valley by at least
+    DEFAULT_DRYBACK_MIN_DROP_PCT.
+    """
+    peak_ts: datetime | None = None
+    peak_vwc: float | None = None
+    peak_ec: float | None = None
+    valley_ts: datetime | None = None
+    valley_vwc: float | None = None
+    valley_ec: float | None = None
+
+
+class RootZoneIntelligence(IntelligenceApp):
     """AppDaemon entry point."""
 
     def initialize(self) -> None:  # noqa: D401 — AppDaemon contract
         self.bus = RootSenseBus.instance()
-        db_path = Path(self.app_dir) / "crop_steering" / "state" / "rootsense.db"
-        self.store = RootSenseStore(db_path)
+        self.store = RootSenseStore(self._state_dir() / "rootsense.db")
 
         cfg = self.args or {}
         self.response_window_sec: int = int(cfg.get("response_window_sec", DEFAULT_RESPONSE_WINDOW_SEC))
@@ -85,25 +105,63 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
         self.fc_confidence_threshold: float = float(
             cfg.get("fc_confidence_threshold", DEFAULT_FC_CONFIDENCE_THRESHOLD)
         )
+        self.sample_interval_sec: int = int(cfg.get("sample_interval_sec", DEFAULT_SAMPLE_INTERVAL_SEC))
+        self.buffer_hours: int = int(cfg.get("buffer_hours", DEFAULT_BUFFER_HOURS))
+        self.dryback_min_drop_pct: float = float(cfg.get("dryback_min_drop_pct", DEFAULT_DRYBACK_MIN_DROP_PCT))
+        self.dryback_min_duration_min: float = float(
+            cfg.get("dryback_min_duration_min", DEFAULT_DRYBACK_MIN_DURATION_MIN)
+        )
+
+        # Buffer length: one sample per `sample_interval_sec`, kept for `buffer_hours`.
+        buf_len = max(60, int(self.buffer_hours * 3600 / self.sample_interval_sec))
+        self._vwc_buf: dict[int, Deque[tuple[datetime, float]]] = defaultdict(lambda: deque(maxlen=buf_len))
+        self._ec_buf: dict[int, Deque[tuple[datetime, float]]] = defaultdict(lambda: deque(maxlen=buf_len))
 
         self._pending: dict[int, ShotResponse] = {}
         self._fc: dict[int, FieldCapacityState] = defaultdict(FieldCapacityState)
+        self._dryback: dict[int, DrybackTracker] = defaultdict(DrybackTracker)
 
         # Bridge HA event bus into RootSenseBus
         self.listen_event(self._on_shot_fired, "crop_steering_irrigation_shot")
 
-        # Periodic publication of derived sensors (decoupled from shot rate)
-        self.run_every(self._publish_derived_sensors, "now+30", 60)
+        # Sample sensors and publish derived metrics every minute (default).
+        self.run_every(self._tick, "now+30", self.sample_interval_sec)
 
         # Daily prune
         self.run_daily(self._daily_prune, "03:30:00")
 
-        self.log("RootZoneIntelligence ready (window=%ds, sat-Δ=%.2f%%)",
-                 self.response_window_sec, self.saturation_delta_pct)
+        self.log(
+            "RootZoneIntelligence ready (window=%ds sat-Δ=%.2f%% sample=%ds buf=%dh)",
+            self.response_window_sec,
+            self.saturation_delta_pct,
+            self.sample_interval_sec,
+            self.buffer_hours,
+        )
 
-    # ------------------------------------------------------------------ events
+    # ------------------------------------------------------------------ tick
+
+    def _tick(self, _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
+        now = datetime.utcnow()
+        for zone in self._configured_zones():
+            vwc = self._read_zone_vwc(zone)
+            ec = self._read_float(f"sensor.crop_steering_zone_{zone}_avg_ec")
+            if vwc is not None:
+                self._vwc_buf[zone].append((now, vwc))
+                self._step_dryback_tracker(zone, now, vwc, ec)
+            if ec is not None:
+                self._ec_buf[zone].append((now, ec))
+
+            self._publish_dryback_velocity(zone)
+            self._publish_porosity_estimate(zone)
+            self._publish_ec_stack_index(zone)
+
+    # ------------------------------------------------------------------ shot lifecycle
 
     def _on_shot_fired(self, event_name: str, data: dict[str, Any], _kwargs: Any) -> None:
+        if not self._is_module_enabled():
+            return
         zone = int(data.get("zone", 0))
         if zone <= 0:
             return
@@ -111,7 +169,13 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
         if pre_vwc is None:
             self.log("Skipping shot response capture for zone %s: VWC unavailable", zone)
             return
-        self._pending[zone] = ShotResponse(zone=zone, pre_vwc=pre_vwc, fired_at=datetime.utcnow())
+        self._pending[zone] = ShotResponse(
+            zone=zone,
+            pre_vwc=pre_vwc,
+            pre_ec=self._read_float(f"sensor.crop_steering_zone_{zone}_avg_ec"),
+            fired_at=datetime.utcnow(),
+            volume_ml=data.get("volume_ml"),
+        )
         self.run_in(self._capture_peak, self.response_window_sec, zone=zone)
 
     def _capture_peak(self, kwargs: dict[str, Any]) -> None:
@@ -119,7 +183,7 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
         record = self._pending.pop(zone, None)
         if record is None:
             return
-        peak_vwc = self._read_zone_vwc_peak_since(zone, record.fired_at)
+        peak_vwc = self._peak_vwc_in_buffer_since(zone, record.fired_at)
         if peak_vwc is None:
             return
         record.peak_vwc = peak_vwc
@@ -129,9 +193,21 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
             "zone": zone,
             "pre_vwc": record.pre_vwc,
             "peak_vwc": peak_vwc,
-            "delta": record.delta,
+            "delta": record.delta_vwc,
+            "volume_ml": record.volume_ml,
             "fired_at": record.fired_at.isoformat(),
         })
+
+        # Persist the response for porosity estimation.
+        self.store.record_shot(
+            ts=record.fired_at.isoformat(),
+            zone=zone,
+            shot_type="response",
+            volume_ml=record.volume_ml,
+            vwc_before=record.pre_vwc,
+            vwc_peak=peak_vwc,
+            ec_feed=record.pre_ec,
+        )
 
         self._update_field_capacity(record)
 
@@ -182,14 +258,6 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
             "confidence": round(fc.confidence, 2),
         })
 
-    # ------------------------------------------------------------------ derived sensors
-
-    def _publish_derived_sensors(self, _kwargs: Any) -> None:
-        for zone in self._configured_zones():
-            self._publish_dryback_velocity(zone)
-            self._publish_porosity_estimate(zone)
-            self._publish_ec_stack_index(zone)
-
     def _publish_fc_sensor(self, zone: int, fc: FieldCapacityState) -> None:
         self.set_state(
             f"sensor.crop_steering_zone_{zone}_field_capacity_observed",
@@ -203,56 +271,200 @@ class RootZoneIntelligence(hass.Hass):  # type: ignore[misc]
             },
         )
 
+    # ------------------------------------------------------------------ dryback episodes
+
+    def _step_dryback_tracker(self, zone: int, now: datetime, vwc: float, ec: float | None) -> None:
+        """Update the per-zone peak/valley tracker with the latest sample.
+
+        State machine:
+          1. Initial: no peak yet → first sample becomes a candidate peak.
+          2. Tracking peak: each higher VWC raises the peak.
+          3. Once VWC has dropped from peak by >= dryback_min_drop_pct, we
+             leave "rising" and start tracking valley.
+          4. Each lower VWC lowers the valley.
+          5. When VWC rises from valley by >= dryback_min_drop_pct AND the
+             peak-to-now duration is >= dryback_min_duration_min, we emit a
+             DrybackEpisode and reset (the new sample becomes the next peak
+             candidate).
+        """
+        t = self._dryback[zone]
+
+        if t.peak_vwc is None or vwc > t.peak_vwc:
+            # Either fresh start or new (higher) peak found.
+            t.peak_ts, t.peak_vwc, t.peak_ec = now, vwc, ec
+            t.valley_ts, t.valley_vwc, t.valley_ec = None, None, None
+            return
+
+        # We are currently in a dryback (post-peak). Track the running valley.
+        if t.valley_vwc is None or vwc < t.valley_vwc:
+            t.valley_ts, t.valley_vwc, t.valley_ec = now, vwc, ec
+
+        # Rebound check: have we risen far enough from the valley to call the
+        # episode done?
+        if t.valley_vwc is not None and vwc - t.valley_vwc >= self.dryback_min_drop_pct:
+            if t.peak_ts and t.valley_ts:
+                duration_min = (t.valley_ts - t.peak_ts).total_seconds() / 60.0
+                drop_pct = (t.peak_vwc or 0.0) - t.valley_vwc
+                if duration_min >= self.dryback_min_duration_min and drop_pct >= self.dryback_min_drop_pct:
+                    self._emit_dryback_episode(zone, t)
+            # Reset and start a new peak candidate at the current sample.
+            t.peak_ts, t.peak_vwc, t.peak_ec = now, vwc, ec
+            t.valley_ts, t.valley_vwc, t.valley_ec = None, None, None
+
+    def _emit_dryback_episode(self, zone: int, t: DrybackTracker) -> None:
+        peak_vwc = t.peak_vwc or 0.0
+        valley_vwc = t.valley_vwc or 0.0
+        duration_min = ((t.valley_ts or datetime.utcnow()) - (t.peak_ts or datetime.utcnow())).total_seconds() / 60.0
+        drop_pct = peak_vwc - valley_vwc
+        slope = (drop_pct / duration_min * 60.0) if duration_min > 0 else 0.0
+        phase = self.get_state("select.crop_steering_irrigation_phase") or "unknown"
+        payload = {
+            "zone": zone,
+            "peak_ts": (t.peak_ts or datetime.utcnow()).isoformat(),
+            "valley_ts": (t.valley_ts or datetime.utcnow()).isoformat(),
+            "peak_vwc": round(peak_vwc, 2),
+            "valley_vwc": round(valley_vwc, 2),
+            "pct": round(drop_pct, 2),
+            "duration_min": round(duration_min, 1),
+            "slope_pct_h": round(slope, 3),
+            "phase": phase,
+            "ec_at_peak": t.peak_ec,
+            "ec_at_valley": t.valley_ec,
+        }
+        self.store.record_dryback_episode(**payload)
+        self.bus.publish("dryback.complete", payload)
+        self.fire_event("crop_steering_dryback_complete", **payload)
+        self.log(
+            "Zone %s dryback complete: %.1f%% drop over %.1fmin (%.2f%%/h) phase=%s",
+            zone, drop_pct, duration_min, slope, phase,
+        )
+
+    # ------------------------------------------------------------------ derived sensors
+
     def _publish_dryback_velocity(self, zone: int) -> None:
-        # Stub: real implementation reads the existing AdvancedDrybackDetector's
-        # rolling dryback rate. Placeholder publishes "unknown" until wired.
-        pass
+        """Expose recent dryback velocity (%/h) as a sensor.
+
+        Computed from the last hour of the VWC buffer: slope of a simple
+        linear fit between (oldest, current) within the buffer window. We
+        intentionally keep this naive — the real episode boundaries come
+        from `_step_dryback_tracker` above; this sensor is a smoothed
+        live-rate indicator for dashboards and the OptimisationLoop reward.
+        """
+        buf = list(self._vwc_buf[zone])
+        if len(buf) < 5:
+            return
+        cutoff = datetime.utcnow() - timedelta(hours=1)
+        recent = [(ts, v) for ts, v in buf if ts >= cutoff]
+        if len(recent) < 5:
+            return
+        first_ts, first_v = recent[0]
+        last_ts, last_v = recent[-1]
+        delta_h = (last_ts - first_ts).total_seconds() / 3600.0
+        if delta_h <= 0:
+            return
+        slope_pct_per_hr = (last_v - first_v) / delta_h  # negative = drying
+        self.set_state(
+            f"sensor.crop_steering_zone_{zone}_dryback_velocity_pct_per_hr",
+            state=round(-slope_pct_per_hr, 3),  # report as positive when drying
+            attributes={
+                "sample_count": len(recent),
+                "window_hours": 1,
+                "raw_slope_pct_per_hr": round(slope_pct_per_hr, 3),
+                "unit_of_measurement": "%/h",
+                "friendly_name": f"Zone {zone} dryback velocity",
+                "icon": "mdi:speedometer-slow",
+                "state_class": "measurement",
+            },
+        )
 
     def _publish_porosity_estimate(self, zone: int) -> None:
-        # Stub: porosity ≈ ΔVWC per mL applied; computed from `shots` table.
-        pass
+        """ΔVWC per mL applied across the last 24h of stored shots.
+
+        A higher value means a small shot moves VWC further — a proxy for
+        substrate porosity / effective volume. Used by ShotPlanner in
+        Phase 2.
+        """
+        recent_shots = self.store.recent_shots(zone, hours=24)
+        usable = [
+            s for s in recent_shots
+            if s.get("volume_ml") and s.get("vwc_before") is not None and s.get("vwc_peak") is not None
+        ]
+        if not usable:
+            return
+        ratios = []
+        for s in usable:
+            vol = float(s["volume_ml"])
+            delta = float(s["vwc_peak"]) - float(s["vwc_before"])
+            if vol > 0 and delta > 0:
+                ratios.append(delta / vol)  # %VWC per mL
+        if not ratios:
+            return
+        ratios.sort()
+        median = ratios[len(ratios) // 2]
+        self.set_state(
+            f"sensor.crop_steering_zone_{zone}_substrate_porosity_estimate_ml_per_pct",
+            state=round(1.0 / median if median > 0 else 0.0, 2),
+            attributes={
+                "sample_count": len(ratios),
+                "median_pct_vwc_per_ml": round(median, 4),
+                "window_hours": 24,
+                "unit_of_measurement": "mL/%VWC",
+                "friendly_name": f"Zone {zone} substrate porosity",
+                "icon": "mdi:dots-grid",
+                "state_class": "measurement",
+            },
+        )
 
     def _publish_ec_stack_index(self, zone: int) -> None:
-        # Stub: cumulative (ec_runoff - ec_feed) integral over a window.
-        pass
+        """Cumulative EC drift index over the last 6 hours.
+
+        Sum of (EC[t] - EC[t-1]) clipped to positive values, integrated across
+        the buffer window. A monotonically rising EC stack indicates salt
+        accumulation — the OptimisationLoop and AnomalyScanner both watch
+        this for flush triggers.
+        """
+        buf = list(self._ec_buf[zone])
+        if len(buf) < 5:
+            return
+        cutoff = datetime.utcnow() - timedelta(hours=6)
+        recent = [(ts, v) for ts, v in buf if ts >= cutoff]
+        if len(recent) < 5:
+            return
+        stack = 0.0
+        for (_, prev), (_, curr) in zip(recent, recent[1:]):
+            delta = curr - prev
+            if delta > 0:
+                stack += delta
+        self.set_state(
+            f"sensor.crop_steering_zone_{zone}_ec_stack_index",
+            state=round(stack, 3),
+            attributes={
+                "sample_count": len(recent),
+                "window_hours": 6,
+                "unit_of_measurement": "mS/cm",
+                "friendly_name": f"Zone {zone} EC stack index",
+                "icon": "mdi:layers-triple-outline",
+                "state_class": "measurement",
+            },
+        )
 
     # ------------------------------------------------------------------ helpers
 
     def _read_zone_vwc(self, zone: int) -> float | None:
-        state = self.get_state(f"sensor.crop_steering_zone_{zone}_avg_vwc")
-        try:
-            return float(state)  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return None
+        return self._read_float(f"sensor.crop_steering_zone_{zone}_avg_vwc")
 
-    def _read_zone_vwc_peak_since(self, zone: int, since: datetime) -> float | None:
-        # AppDaemon doesn't expose history directly; the master app maintains
-        # rolling buffers. For now, just sample current VWC — wired to the
-        # real buffer in PR #2.
+    def _peak_vwc_in_buffer_since(self, zone: int, since: datetime) -> float | None:
+        buf = self._vwc_buf[zone]
+        candidates = [v for ts, v in buf if ts >= since]
+        if candidates:
+            return max(candidates)
         return self._read_zone_vwc(zone)
 
     def _read_zone_cultivar(self, zone: int) -> str | None:
         return self.get_state(f"select.crop_steering_zone_{zone}_crop_type")  # type: ignore[return-value]
-
-    def _configured_zones(self) -> list[int]:
-        # Cheap discovery: scan for state.crop_steering_zone_{n}_avg_vwc for n in 1..24
-        zones = []
-        for n in range(1, 25):
-            if self.entity_exists(f"sensor.crop_steering_zone_{n}_avg_vwc"):
-                zones.append(n)
-        return zones
 
     def _daily_prune(self, _kwargs: Any) -> None:
         try:
             self.store.prune()
         except Exception:  # noqa: BLE001
             self.log("Daily prune failed", level="ERROR")
-
-    # ------------------------------------------------------------------ AppDaemon shims
-
-    def entity_exists(self, entity_id: str) -> bool:
-        # AppDaemon ≥4.4 has self.entity_exists; shim for older versions.
-        try:
-            return super().entity_exists(entity_id)  # type: ignore[misc]
-        except AttributeError:
-            return self.get_state(entity_id) is not None

--- a/appdaemon/apps/crop_steering/intelligence/store.py
+++ b/appdaemon/apps/crop_steering/intelligence/store.py
@@ -1,0 +1,236 @@
+"""SQLite analytics store for RootSense.
+
+Single file at ``appdaemon/apps/crop_steering/state/rootsense.db`` (the
+``state/`` directory is created on first use). All writes go through this
+class so retention, schema migrations, and VACUUM are centralised.
+
+Tables:
+
+- ``shots``             — every irrigation shot (planned, fired, observed)
+- ``dryback_episodes``  — peak → valley pairs with timing & EC context
+- ``field_capacity``    — accepted FC observations per zone/cultivar
+- ``anomalies``         — every anomaly the scanner has raised
+- ``run_reports``       — JSON blobs from the nightly aggregator
+- ``optimisation``      — per-zone posterior parameters for the bandit loop
+
+Designed to be tiny — a year of 6-zone operation is well under 100 MB.
+Daily VACUUM keeps fragmentation in check.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterator
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_RETENTION_DAYS = 90
+
+SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS shots (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts            TEXT    NOT NULL,
+        zone          INTEGER NOT NULL,
+        phase         TEXT,
+        shot_type     TEXT,           -- planned | custom | emergency | flush
+        intent        REAL,           -- cultivator intent at the time
+        volume_ml     REAL,
+        duration_s    REAL,
+        vwc_before    REAL,
+        vwc_peak      REAL,
+        ec_feed       REAL,
+        ec_runoff     REAL,
+        runoff_pct    REAL,
+        tag           TEXT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dryback_episodes (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        zone          INTEGER NOT NULL,
+        peak_ts       TEXT    NOT NULL,
+        valley_ts     TEXT    NOT NULL,
+        peak_vwc      REAL,
+        valley_vwc    REAL,
+        pct           REAL,
+        duration_min  REAL,
+        slope_pct_h   REAL,
+        phase         TEXT,
+        ec_at_peak    REAL,
+        ec_at_valley  REAL,
+        vpd_avg       REAL,
+        dli_partial   REAL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS field_capacity (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts            TEXT    NOT NULL,
+        zone          INTEGER NOT NULL,
+        cultivar      TEXT,
+        fc_pct        REAL    NOT NULL,
+        confidence    REAL    NOT NULL,
+        sample_count  INTEGER NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS anomalies (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts            TEXT    NOT NULL,
+        zone          INTEGER,
+        code          TEXT    NOT NULL,
+        severity      TEXT    NOT NULL,         -- info | warning | critical
+        evidence      TEXT,
+        remediation   TEXT,
+        resolved_ts   TEXT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS run_reports (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_date      TEXT    NOT NULL UNIQUE,
+        payload_json  TEXT    NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS optimisation (
+        zone          INTEGER PRIMARY KEY,
+        posterior_json TEXT   NOT NULL,
+        updated_ts    TEXT    NOT NULL
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_shots_zone_ts ON shots(zone, ts);",
+    "CREATE INDEX IF NOT EXISTS idx_dryback_zone_peak ON dryback_episodes(zone, peak_ts);",
+    "CREATE INDEX IF NOT EXISTS idx_anomalies_ts ON anomalies(ts);",
+]
+
+
+class RootSenseStore:
+    """Thread-safe SQLite wrapper. One instance per AppDaemon process."""
+
+    def __init__(self, db_path: Path | str, retention_days: int = DEFAULT_RETENTION_DAYS) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.retention_days = retention_days
+        self._lock = threading.RLock()
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._conn() as c:
+            for stmt in SCHEMA:
+                c.execute(stmt)
+
+    @contextmanager
+    def _conn(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            con = sqlite3.connect(self.db_path, timeout=10.0, isolation_level=None)
+            try:
+                con.execute("PRAGMA journal_mode=WAL;")
+                con.execute("PRAGMA synchronous=NORMAL;")
+                yield con
+            finally:
+                con.close()
+
+    # ------------------------------------------------------------------ writers
+
+    def record_shot(self, **fields: Any) -> int:
+        cols = ", ".join(fields.keys())
+        placeholders = ", ".join(["?"] * len(fields))
+        with self._conn() as c:
+            cur = c.execute(f"INSERT INTO shots ({cols}) VALUES ({placeholders})", tuple(fields.values()))
+            return int(cur.lastrowid)
+
+    def record_dryback_episode(self, **fields: Any) -> int:
+        cols = ", ".join(fields.keys())
+        placeholders = ", ".join(["?"] * len(fields))
+        with self._conn() as c:
+            cur = c.execute(
+                f"INSERT INTO dryback_episodes ({cols}) VALUES ({placeholders})",
+                tuple(fields.values()),
+            )
+            return int(cur.lastrowid)
+
+    def record_field_capacity(self, ts: str, zone: int, cultivar: str | None,
+                              fc_pct: float, confidence: float, sample_count: int) -> None:
+        with self._conn() as c:
+            c.execute(
+                "INSERT INTO field_capacity (ts, zone, cultivar, fc_pct, confidence, sample_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ts, zone, cultivar, fc_pct, confidence, sample_count),
+            )
+
+    def record_anomaly(self, ts: str, zone: int | None, code: str, severity: str,
+                       evidence: str, remediation: str) -> int:
+        with self._conn() as c:
+            cur = c.execute(
+                "INSERT INTO anomalies (ts, zone, code, severity, evidence, remediation) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ts, zone, code, severity, evidence, remediation),
+            )
+            return int(cur.lastrowid)
+
+    def write_run_report(self, run_date: str, payload: dict[str, Any]) -> None:
+        with self._conn() as c:
+            c.execute(
+                "INSERT OR REPLACE INTO run_reports (run_date, payload_json) VALUES (?, ?)",
+                (run_date, json.dumps(payload)),
+            )
+
+    def upsert_posterior(self, zone: int, posterior: dict[str, Any]) -> None:
+        with self._conn() as c:
+            c.execute(
+                "INSERT INTO optimisation (zone, posterior_json, updated_ts) VALUES (?, ?, ?) "
+                "ON CONFLICT(zone) DO UPDATE SET posterior_json=excluded.posterior_json, "
+                "updated_ts=excluded.updated_ts",
+                (zone, json.dumps(posterior), datetime.utcnow().isoformat()),
+            )
+
+    # ------------------------------------------------------------------ readers
+
+    def latest_field_capacity(self, zone: int) -> tuple[float, float] | None:
+        """Returns (fc_pct, confidence) or None if no observation yet."""
+        with self._conn() as c:
+            row = c.execute(
+                "SELECT fc_pct, confidence FROM field_capacity "
+                "WHERE zone = ? ORDER BY ts DESC LIMIT 1",
+                (zone,),
+            ).fetchone()
+            return (row[0], row[1]) if row else None
+
+    def recent_shots(self, zone: int, hours: int = 24) -> list[dict[str, Any]]:
+        cutoff = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+        with self._conn() as c:
+            c.row_factory = sqlite3.Row
+            rows = c.execute(
+                "SELECT * FROM shots WHERE zone = ? AND ts >= ? ORDER BY ts ASC",
+                (zone, cutoff),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def load_posterior(self, zone: int) -> dict[str, Any] | None:
+        with self._conn() as c:
+            row = c.execute(
+                "SELECT posterior_json FROM optimisation WHERE zone = ?",
+                (zone,),
+            ).fetchone()
+            return json.loads(row[0]) if row else None
+
+    # ------------------------------------------------------------------ retention
+
+    def prune(self) -> None:
+        cutoff = (datetime.utcnow() - timedelta(days=self.retention_days)).isoformat()
+        with self._conn() as c:
+            for table, ts_col in [
+                ("shots", "ts"),
+                ("dryback_episodes", "peak_ts"),
+                ("anomalies", "ts"),
+            ]:
+                c.execute(f"DELETE FROM {table} WHERE {ts_col} < ?", (cutoff,))
+            c.execute("VACUUM;")
+        _LOGGER.info("RootSense store pruned (retention=%s days)", self.retention_days)

--- a/custom_components/crop_steering/__init__.py
+++ b/custom_components/crop_steering/__init__.py
@@ -3,14 +3,36 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from typing import Any
+
+try:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import Platform
+    from homeassistant.core import HomeAssistant
+    from homeassistant.exceptions import ConfigEntryNotReady
+    from homeassistant.helpers import entity_registry as er
+except ImportError:  # pragma: no cover - enables non-HA unit tests
+    ConfigEntry = Any  # type: ignore
+    HomeAssistant = Any  # type: ignore
+    ConfigEntryNotReady = Exception  # type: ignore
+
+    class Platform:  # type: ignore
+        SENSOR = "sensor"
+        SWITCH = "switch"
+        SELECT = "select"
+        NUMBER = "number"
+        BUTTON = "button"
 
 from .const import DOMAIN, CONF_NUM_ZONES
-from .services import async_setup_services, async_unload_services
+
+try:
+    from .services import async_setup_services, async_unload_services
+except ImportError:  # pragma: no cover - enables non-HA unit tests
+    async def async_setup_services(_hass: HomeAssistant) -> None:
+        return None
+
+    async def async_unload_services(_hass: HomeAssistant) -> None:
+        return None
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/crop_steering/calculations.py
+++ b/custom_components/crop_steering/calculations.py
@@ -1,0 +1,21 @@
+"""Pure calculation helpers for crop steering."""
+
+from __future__ import annotations
+
+from .const import PERCENTAGE_TO_RATIO, SECONDS_PER_HOUR
+
+
+class ShotCalculator:
+    """Helper class for irrigation shot calculations."""
+
+    @staticmethod
+    def calculate_shot_duration(dripper_flow: float, substrate_vol: float, shot_size: float) -> float:
+        """Calculate irrigation shot duration in seconds."""
+        try:
+            if dripper_flow and dripper_flow > 0:
+                volume_to_add = substrate_vol * (shot_size * PERCENTAGE_TO_RATIO)
+                duration_hours = volume_to_add / dripper_flow
+                return round(duration_hours * SECONDS_PER_HOUR, 1)
+            return 0.0
+        except Exception:
+            return 0.0

--- a/custom_components/crop_steering/const.py
+++ b/custom_components/crop_steering/const.py
@@ -22,8 +22,38 @@ DEFAULT_SUBSTRATE_VOLUME = 10.0
 DEFAULT_DRIPPER_FLOW_RATE = 2.0
 DEFAULT_FIELD_CAPACITY = 70.0
 DEFAULT_MAX_EC = 9.0
-DEFAULT_VEG_DRYBACK_TARGET = 50.0
-DEFAULT_GEN_DRYBACK_TARGET = 40.0
+
+# ---------------------------------------------------------------------------
+# P0 dryback configuration
+# ---------------------------------------------------------------------------
+# IMPORTANT: in this codebase "dryback" is always the *drop* from peak VWC,
+# expressed as percentage points. e.g. peak=70%, valley=58% ⇒ dryback = 12.
+# It is NOT the VWC value the substrate dries down *to*.
+#
+# The two endpoints below feed:
+#   - the legacy `master_crop_steering_app` P0 exit predicate, and
+#   - the RootSense IntentResolver, which interpolates between them via the
+#     cultivator-intent slider (-100 = pure generative ⇒ DROP_PCT_GEN,
+#     +100 = pure vegetative ⇒ DROP_PCT_VEG).
+#
+# Defaults reflect Athena cannabis guidance (10-15% veg, 20-25% gen). They are
+# *only* defaults; the values are surfaced as HA `number` entities so the
+# cultivator can override per cultivar at any time without touching code:
+#
+#   number.crop_steering_veg_p0_dryback_drop_pct   (range 5-40)
+#   number.crop_steering_gen_p0_dryback_drop_pct   (range 5-50)
+#
+# The legacy entities `number.crop_steering_veg_dryback_target` /
+# `number.crop_steering_gen_dryback_target` are kept as aliases for backward
+# compatibility (see number.py) but emit a deprecation warning in the log.
+DEFAULT_VEG_P0_DRYBACK_DROP_PCT = 12.0
+DEFAULT_GEN_P0_DRYBACK_DROP_PCT = 22.0
+
+# Legacy aliases — kept so existing dashboards / env files continue to load.
+# Numerically these used to mean "% drop from peak"; the previous defaults of
+# 50 / 40 were too aggressive under that semantic and are corrected here.
+DEFAULT_VEG_DRYBACK_TARGET = DEFAULT_VEG_P0_DRYBACK_DROP_PCT  # legacy alias
+DEFAULT_GEN_DRYBACK_TARGET = DEFAULT_GEN_P0_DRYBACK_DROP_PCT  # legacy alias
 DEFAULT_P1_TARGET_VWC = 65.0
 DEFAULT_P2_VWC_THRESHOLD = 60.0
 

--- a/custom_components/crop_steering/number.py
+++ b/custom_components/crop_steering/number.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, CONF_NUM_ZONES, SOFTWARE_VERSION
+from .const import (
+    DOMAIN,
+    CONF_NUM_ZONES,
+    SOFTWARE_VERSION,
+    DEFAULT_VEG_P0_DRYBACK_DROP_PCT,
+    DEFAULT_GEN_P0_DRYBACK_DROP_PCT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,25 +71,55 @@ NUMBER_DESCRIPTIONS = [
         native_unit_of_measurement="mS/cm",
         mode="box",
     ),
+    # ----- Operator-facing P0 dryback drop sliders (RootSense v3) -----
+    # Both express "percentage point drop from peak VWC" — i.e. how much the
+    # substrate dries back BY, not what it dries back TO. Veg defaults small
+    # (10-15% drop), generative defaults larger (20-25% drop).
     NumberEntityDescription(
-        key="veg_dryback_target",
-        name="Vegetative Dryback Target",
+        key="veg_p0_dryback_drop_pct",
+        name="Vegetative P0 Dryback Drop %",
         icon="mdi:water-minus",
-        native_min_value=20.0,
-        native_max_value=80.0,
-        native_step=1.0,
+        native_min_value=2.0,
+        native_max_value=40.0,
+        native_step=0.5,
         native_unit_of_measurement=PERCENTAGE,
         mode="box",
     ),
     NumberEntityDescription(
-        key="gen_dryback_target",
-        name="Generative Dryback Target", 
+        key="gen_p0_dryback_drop_pct",
+        name="Generative P0 Dryback Drop %",
         icon="mdi:water-minus",
-        native_min_value=15.0,
+        native_min_value=2.0,
+        native_max_value=50.0,
+        native_step=0.5,
+        native_unit_of_measurement=PERCENTAGE,
+        mode="box",
+    ),
+    # ----- Legacy entries kept for backward compatibility -----
+    # Read by master_crop_steering_app and legacy dashboards. Same numeric
+    # semantic ("% drop from peak"); these will be hidden in v3.1 once the
+    # new entities are in widespread use.
+    NumberEntityDescription(
+        key="veg_dryback_target",
+        name="Vegetative Dryback Target (legacy)",
+        icon="mdi:water-minus",
+        native_min_value=2.0,
+        native_max_value=80.0,
+        native_step=1.0,
+        native_unit_of_measurement=PERCENTAGE,
+        mode="box",
+        entity_registry_enabled_default=True,
+    ),
+    NumberEntityDescription(
+        key="gen_dryback_target",
+        name="Generative Dryback Target (legacy)",
+        icon="mdi:water-minus",
+        native_min_value=2.0,
         native_max_value=70.0,
         native_step=1.0,
         native_unit_of_measurement=PERCENTAGE,
         mode="box",
+        entity_registry_enabled_default=True,
     ),
     NumberEntityDescription(
         key="p1_target_vwc",
@@ -537,8 +573,14 @@ class CropSteeringNumber(NumberEntity, RestoreEntity):
             "drippers_per_plant": 2,
             "field_capacity": 70.0,
             "max_ec": 9.0,
-            "veg_dryback_target": 50.0,
-            "gen_dryback_target": 40.0,
+            # New canonical entities (RootSense v3)
+            "veg_p0_dryback_drop_pct": DEFAULT_VEG_P0_DRYBACK_DROP_PCT,
+            "gen_p0_dryback_drop_pct": DEFAULT_GEN_P0_DRYBACK_DROP_PCT,
+            # Legacy aliases — same semantic ("% drop from peak"), corrected
+            # defaults. Old defaults (50/40) were too aggressive and now
+            # follow the same Athena-style values as the new entities.
+            "veg_dryback_target": DEFAULT_VEG_P0_DRYBACK_DROP_PCT,
+            "gen_dryback_target": DEFAULT_GEN_P0_DRYBACK_DROP_PCT,
             "p1_target_vwc": 65.0,
             "p2_vwc_threshold": 60.0,
             # P0 Phase Defaults

--- a/custom_components/crop_steering/sensor.py
+++ b/custom_components/crop_steering/sensor.py
@@ -22,28 +22,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
-    DOMAIN, CONF_NUM_ZONES, SECONDS_PER_HOUR, PERCENTAGE_TO_RATIO,
+    DOMAIN, CONF_NUM_ZONES,
     DEFAULT_EC_RATIO, DEFAULT_EC_FALLBACK, VWC_ADJUSTMENT_PERCENT,
     VWC_DRY_THRESHOLD, VWC_SATURATED_THRESHOLD, SOFTWARE_VERSION
 )
+from .calculations import ShotCalculator
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class ShotCalculator:
-    """Helper class for irrigation shot calculations."""
-    
-    @staticmethod
-    def calculate_shot_duration(dripper_flow: float, substrate_vol: float, shot_size: float) -> float:
-        """Calculate irrigation shot duration in seconds."""
-        try:
-            if dripper_flow > 0:
-                volume_to_add = substrate_vol * (shot_size * PERCENTAGE_TO_RATIO)
-                duration_hours = volume_to_add / dripper_flow
-                return round(duration_hours * SECONDS_PER_HOUR, 1)
-            return 0.0
-        except Exception:
-            return 0.0
 
 
 # Base sensor descriptions (non-zone specific)

--- a/custom_components/crop_steering/switch.py
+++ b/custom_components/crop_steering/switch.py
@@ -37,6 +37,36 @@ BASE_SWITCH_DESCRIPTIONS = [
         name="Analytics Enabled",
         icon="mdi:chart-line",
     ),
+    # ----- RootSense intelligence module enable switches -----
+    # Each pillar reads its corresponding switch on every iteration. When OFF,
+    # the module logs "skipped" and short-circuits without touching state or
+    # publishing sensors. Defaults: all OFF so existing v2.x installs are
+    # unaffected on first upgrade. Operators opt in pillar-by-pillar.
+    SwitchEntityDescription(
+        key="intelligence_root_zone_enabled",
+        name="RootSense — Root Zone Intelligence",
+        icon="mdi:water-percent-alert",
+    ),
+    SwitchEntityDescription(
+        key="intelligence_adaptive_enabled",
+        name="RootSense — Adaptive Irrigation",
+        icon="mdi:tune-vertical-variant",
+    ),
+    SwitchEntityDescription(
+        key="intelligence_agronomic_enabled",
+        name="RootSense — Agronomic Intelligence",
+        icon="mdi:sprout",
+    ),
+    SwitchEntityDescription(
+        key="intelligence_orchestrator_enabled",
+        name="RootSense — Orchestrator",
+        icon="mdi:hub-outline",
+    ),
+    SwitchEntityDescription(
+        key="intelligence_anomaly_enabled",
+        name="RootSense — Anomaly Scanner",
+        icon="mdi:alert-decagram-outline",
+    ),
 ]
 
 

--- a/docs/upgrade/GAP_ANALYSIS_2026-05.md
+++ b/docs/upgrade/GAP_ANALYSIS_2026-05.md
@@ -1,0 +1,40 @@
+# HA Crop Steward — Gap Analysis (May 3, 2026)
+
+## Executive Summary
+The repository already contains substantial groundwork for AROYA-like capabilities (root-zone analytics, adaptive irrigation, anomaly hooks, and orchestration modules). However, several gaps remain before production parity: module-level configurability is only partial, second-brain incident workflows are incomplete, and testability is weak outside a Home Assistant runtime.
+
+## Current vs Target Gaps
+
+| Target Module | Current State | Gap | Priority |
+|---|---|---|---|
+| SUBSTR AIT (root-zone intelligence) | `intelligence/root_zone.py` + dryback modules present | Field-capacity detection needs explicit calibration workflow + dashboard surfacing | High |
+| AUTOM AIT (adaptive strategy) | `intelligence/adaptive_irrigation.py` + orchestration available | Intent-driven control loop exists but needs clearer operator controls and guardrail observability | High |
+| CULTIV AIT (agronomic intelligence) | `intelligence/agronomic.py` present | Climate-substrate KPIs and transpiration confidence metrics need expanded validation/reporting | Medium |
+| IRRIG AIT (irrigation intelligence) | Orchestrator and custom shots implemented | Manual override UX and feed/runoff reconciliation need tighter guided workflows | High |
+| Second Brain | `intelligence/anomaly.py` + event bus | No full incident report pipeline/remediation playbooks surfaced in docs/UI | High |
+
+## Production Readiness Gaps (Cross-cutting)
+1. **Testing isolation gap**: unit tests depended on Home Assistant imports during collection, blocking CI and local validation.
+2. **Roadmap clarity gap**: no single consolidated phase-by-phase implementation tracker tied to the AROYA-equivalent architecture.
+3. **Operator handoff gap**: README lacked explicit “what is done / what remains” guidance for production deployments.
+
+## To-Do (Prioritized)
+
+### P0 – Immediate
+- [x] Isolate pure calculations from HA runtime for stable unit tests.
+- [x] Add consolidated gap analysis and implementation backlog document.
+- [x] Update README with direct link to gap analysis and execution order.
+
+### P1 – Near-term
+- [ ] Add per-module enable/disable entities for all intelligence modules and ensure they are exposed in blueprints.
+- [ ] Implement incident report generator (markdown/json) from anomaly events with recommended remediation steps.
+- [ ] Add validation suite for climate↔substrate model drift and confidence thresholds.
+
+### P2 – Hardening
+- [ ] Add replay/simulation mode for historical day runs.
+- [ ] Add deterministic integration tests for phase transitions and emergency shots.
+- [ ] Add dashboards for anomaly root-cause timelines and comparative zone diagnostics.
+
+## Notes
+- All recommendations preserve local-only operation and backward compatibility expectations.
+- This document is intended to be the authoritative upgrade tracker for the AROYA-equivalent rollout.

--- a/docs/upgrade/RECONCILIATION.md
+++ b/docs/upgrade/RECONCILIATION.md
@@ -1,0 +1,36 @@
+# RootSense plan ↔ Gap-analysis reconciliation
+
+Two upgrade documents now coexist on this branch:
+
+- `ROOTSENSE_v3_PLAN.md` — full design and 5-phase roadmap (this PR series).
+- `GAP_ANALYSIS_2026-05.md` — module gap snapshot + prioritised To-Do list.
+
+They are complementary, not competing. The gap analysis is the *tracker*;
+the RootSense plan is the *design*. This file says where each gap-analysis
+item lands in the RootSense phase plan, so we don't double-implement or
+forget anything.
+
+## Cross-reference table
+
+| Gap-analysis item | Priority | Where it lands in RootSense plan |
+|---|---|---|
+| Isolate pure calculations from HA runtime for stable unit tests | P0 | Done — `calculations.py` + `tests/conftest.py` (PR #6, codex). Foundation for `tests/intelligence/*` in Phase 1. |
+| Consolidated gap analysis & implementation backlog document | P0 | Done — `GAP_ANALYSIS_2026-05.md`. RootSense plan links to it as the live tracker. |
+| Update README with link to gap analysis & execution order | P0 | Done — codex commit. README also gets a RootSense section in Phase 5. |
+| Per-module enable/disable entities for all intelligence modules, exposed in blueprints | P1 | **Phase 1** — added now: 5 `switch.crop_steering_intelligence_*_enabled` entities + recorder includes. Blueprints in Phase 5. |
+| Incident report generator (markdown/json) from anomaly events with remediation steps | P1 | **Phase 4** — `agronomic.RunAnalytics` already plans to roll up anomalies into the nightly run report's remediation block; gap-analysis ask is just to also serialise the same data as a standalone markdown/json artifact. Will reuse the same code. |
+| Validation suite for climate↔substrate model drift and confidence thresholds | P1 | **Phase 3** — paired with `agronomic.ClimateSubstrateModel` and the VPD-ceiling sensor. |
+| Replay/simulation mode for historical day runs | P2 | **Phase 4 → 5** — extend `OptimisationLoop` with a "shadow" mode that consumes the SQLite store instead of live events. Useful both for rollout and for tuning. |
+| Deterministic integration tests for phase transitions and emergency shots | P2 | **Phase 1 onwards** — covered incrementally. Each phase ships unit tests in `tests/intelligence/`; integration tests using the existing test-helper harness arrive in Phase 5. |
+| Dashboards for anomaly root-cause timelines and comparative zone diagnostics | P2 | **Phase 4** — anomaly-history dashboard + peer-zone comparison view, alongside `dashboards/rootsense_history.yaml`. |
+
+## Execution order, after this commit
+
+1. **Phase 1** (this PR, in progress) — RootZone wiring, module-enable switches, recorder includes.
+2. **Phase 2** — Adaptive Irrigation: cultivator-intent slider goes live, `OptimisationLoop` arms in shadow mode.
+3. **Phase 3** — Agronomic: transpiration sensors, VPD ceiling, climate-substrate validation suite.
+4. **Phase 4** — Orchestration coordinator takes hardware control; anomaly incident-report generator surfaces in HA UI.
+5. **Phase 5** — Blueprints, dashboards, MIGRATION.md, version bump to 3.0.0.
+
+The gap-analysis P0 items are complete. Everything else from the gap
+analysis is folded into RootSense Phases 1-4 above.

--- a/docs/upgrade/ROOTSENSE_v3_PLAN.md
+++ b/docs/upgrade/ROOTSENSE_v3_PLAN.md
@@ -1,0 +1,506 @@
+# RootSense v3.0 — Intelligent Crop Steering Upgrade Plan
+
+> Branch: `feat/intelligent-crop-steering`
+> Target release: Crop Steering v3.0.0 ("RootSense")
+> Status: Planning + scaffolding (this commit)
+> Scope: Evolve `JakeTheRabbit/HA-Irrigation-Strategy` from a rule-based 4-phase
+> controller into a fully adaptive, agronomically aware crop-steering platform
+> running entirely inside Home Assistant + AppDaemon.
+
+---
+
+## 0. Suggested system name
+
+**RootSense** — a four-module intelligence platform layered on top of the
+existing Crop Steering integration. The name signals the substrate-first,
+sensor-driven foundation while leaving room for canopy/agronomic modules.
+
+The four pillars map 1:1 to the user's brief:
+
+| # | Pillar                       | Module package                                        |
+|---|------------------------------|-------------------------------------------------------|
+| 1 | Root Zone Intelligence       | `intelligence/root_zone.py`                           |
+| 2 | Adaptive Irrigation          | `intelligence/adaptive_irrigation.py`                 |
+| 3 | Agronomic Intelligence       | `intelligence/agronomic.py`                           |
+| 4 | Irrigation Orchestration     | `intelligence/orchestration.py` + `anomaly.py`        |
+
+Each pillar is a standalone AppDaemon app, opt-in via `apps.yaml`, sharing a
+single in-memory bus (`RootSenseBus`) and a SQLite-backed analytics store
+(`rootsense.db`) under `appdaemon/apps/crop_steering/state/`.
+
+---
+
+## 1. Executive summary
+
+The current system (`v2.3.1`) is a solid rule-based controller with a 6,263-line
+`master_crop_steering_app.py` doing dryback detection, sensor fusion, phase
+state machine, ML prediction, and hardware sequencing in one process. It works,
+but it is monolithic, the "ML" is a hand-rolled trend tracker, and decisions
+are ultimately driven by static thresholds tuned through HA `number` entities.
+
+RootSense v3.0 turns the controller into an adaptive platform:
+
+- **Field capacity is learned, not configured.** A saturation-event detector
+  watches every irrigation shot, classifies the substrate's response, and
+  publishes a per-zone, per-medium `field_capacity_observed` sensor that the
+  controller uses instead of the static `DEFAULT_FIELD_CAPACITY = 70.0`.
+- **Cultivator intent replaces hard-coded steering modes.** A single
+  `number.crop_steering_steering_intent` (-100 = pure generative, +100 = pure
+  vegetative) continuously re-derives every shot-size, dryback target, and EC
+  threshold via interpolation between calibrated profiles.
+- **The 4-phase machine becomes data-driven.** P0/P1/P2/P3 stay as semantic
+  labels for the operator, but transitions are computed from learned dryback
+  rate, transpiration estimate, and remaining photoperiod — not fixed durations.
+- **Whole-run analytics.** Every shot, dryback, EC drift, and runoff event is
+  written to a local SQLite store. A nightly "agronomic report" event is
+  emitted for the dashboard with per-cultivar, per-phase aggregates.
+- **Cross-cutting anomaly detection.** A dedicated `anomaly.py` runs every
+  minute, comparing each zone against (a) its own rolling baseline and (b) its
+  peers in the same room/cultivar group, surfacing emitter blockages, EC drift,
+  sensor flat-lines, and undetected drybacks before they become yield losses.
+- **Fully local.** Everything runs in AppDaemon with `numpy`, `scipy`, and
+  `scikit-learn` (already on the AppDaemon container). No outbound calls.
+- **Backward compatible.** Existing entities, services, packages, and the
+  ESPHome/MQTT sensor topology stay. Each new module is opt-in; users can
+  enable Root Zone Intelligence first, leave the rest disabled, and incrementally
+  adopt.
+
+---
+
+## 2. Feature mapping
+
+| Current capability (v2.3.x)                                    | New capability (v3.0)                                                                  | Implementation approach                                                                                       |
+|----------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_FIELD_CAPACITY = 70.0` constant                       | Per-zone, per-cultivar **observed field capacity** with confidence score               | `root_zone.FieldCapacityObserver` analyses every saturation→drainage event, EWMA-smoothed per zone            |
+| `AdvancedDrybackDetector` (peaks/valleys, hand-rolled)         | Same detector, **plus** dryback velocity, dryback "shape" classification, runoff link  | Wrap existing detector; add `DrybackEpisode` dataclass persisted to SQLite                                    |
+| Static dashboard cards for VWC/EC                              | **Multi-metric historical visualisation** (VWC, EC, substrate temp, runoff EC, shots) | New `dashboards/rootsense_history.yaml` + ApexCharts cards + `recorder` includes for new sensors              |
+| `STEERING_MODES = ["Vegetative", "Generative"]` select         | **Cultivator-intent slider** (`number.crop_steering_steering_intent`, −100…+100)       | New number entity in `number.py`; profiles interpolated in `adaptive_irrigation.IntentResolver`               |
+| Hard-coded P0 dryback default (`50` veg / `40` gen) with ambiguous "to-or-by?" naming | **Two operator-facing P0 "dries-back-by" sliders**: `number.crop_steering_veg_p0_dryback_drop_pct` (range 2–40, default 12) and `number.crop_steering_gen_p0_dryback_drop_pct` (range 2–50, default 22). Always semantically "% drop from peak VWC". | Endpoints added to `number.py` & `const.py`; `IntentResolver` reads both sliders live every tick and writes the interpolated value to `number.crop_steering_p0_dryback_drop_percent` (the entity the existing P0 exit predicate already consumes) and to `sensor.crop_steering_p0_dryback_drop_pct_current` for dashboards. Legacy `..._dryback_target` entities kept as aliases. |
+| Fixed P1 shot ramp, fixed P2 5% shots                          | **Dynamic shot size** computed from dryback velocity, intent, and field capacity       | `adaptive_irrigation.ShotPlanner` replaces hard-coded percentages                                             |
+| `SimplifiedIrrigationPredictor` (trend extrapolation)          | **Continuous optimisation loop** with reward = (target dryback hit ± runoff EC error)  | `adaptive_irrigation.OptimisationLoop` — bandit-style adjustment of shot size and interval                    |
+| No transpiration model                                         | **VPD + DLI-driven transpiration estimate** per zone                                   | `agronomic.TranspirationModel` (Penman–Monteith approximation, calibrated against measured ΔVWC)              |
+| Per-phase logs only                                            | **Whole-run analytics** (per phase, per zone, per cultivar)                            | SQLite store + nightly aggregation in `agronomic.RunAnalytics`                                                |
+| Manual override switch per zone                                | **On-demand custom irrigation events with full logging**                               | New service `crop_steering.custom_shot` with `intent`, `volume_ml`, `target_runoff_pct`                       |
+| `50_alerts_watchdogs.yaml` (max-runtime watchdog only)         | **Cross-cutting anomaly detection** (emitter, EC drift, sensor flat-line, peer drift) | `anomaly.AnomalyScanner` runs every 60 s, fires `crop_steering_anomaly` events with severity + remediation    |
+| Single `master_crop_steering_app.py` (6.3k lines)              | **Modular intelligence apps** + thin coordinator                                       | Move logic into `intelligence/` package; keep master app as event router                                      |
+| GUI config via `config_flow.py`                                | **Same**, plus per-pillar enable/disable toggles                                       | Extend `config_flow.py` with options-flow step for module enable/disable                                      |
+| AppDaemon `requirements`: `scipy`, `numpy`                     | **Add** `scikit-learn==1.5.*` (locally, no compilation needed on Linux wheels)         | `appdaemon.yaml` `python_packages:`                                                                           |
+
+---
+
+## 3. Step-by-step implementation plan
+
+The plan is broken into five phases. Each phase is independently mergeable, has
+its own test plan, and ships behind feature flags so existing users can opt in.
+
+### Phase 0 — Foundation (this commit)
+
+**Goal:** new directory layout, shared infrastructure, no behaviour change.
+
+Files added in this PR:
+
+- `appdaemon/apps/crop_steering/intelligence/__init__.py`
+- `appdaemon/apps/crop_steering/intelligence/bus.py` — `RootSenseBus`, in-process pub/sub
+- `appdaemon/apps/crop_steering/intelligence/store.py` — SQLite analytics store
+- `appdaemon/apps/crop_steering/intelligence/root_zone.py` — Pillar 1 scaffold
+- `appdaemon/apps/crop_steering/intelligence/adaptive_irrigation.py` — Pillar 2 scaffold
+- `appdaemon/apps/crop_steering/intelligence/agronomic.py` — Pillar 3 scaffold
+- `appdaemon/apps/crop_steering/intelligence/orchestration.py` — Pillar 4 scaffold
+- `appdaemon/apps/crop_steering/intelligence/anomaly.py` — cross-cutting scanner
+- `docs/upgrade/ROOTSENSE_v3_PLAN.md` — this document
+- `blueprints/automation/crop_steering/rootsense_intent.yaml` — operator-facing intent blueprint
+- `CHANGELOG.md` entry under `## [Unreleased]`
+
+The scaffolds are runnable AppDaemon apps that log "ready" on startup but do
+not control hardware. `apps.yaml` is **not** modified yet — opting in is
+documented but not automatic, so existing installs are unaffected.
+
+### Phase 1 — Root Zone Intelligence (PR #2)
+
+1. **Field-capacity observer** (`root_zone.FieldCapacityObserver`)
+   - Subscribes to `crop_steering_irrigation_shot` events.
+   - For each shot, captures pre-shot VWC and post-shot peak (peak detected
+     within `shot_response_window_sec`, default 600 s).
+   - When successive shots produce <0.5% additional VWC rise, declares the
+     zone *saturated* and records the peak as a candidate field-capacity
+     observation.
+   - Maintains an EWMA per (zone, cultivar) and exposes
+     `sensor.crop_steering_zone_{n}_field_capacity_observed` with attributes
+     `confidence`, `sample_count`, `last_updated`.
+   - Confidence ≥ 0.8 → controller switches from `DEFAULT_FIELD_CAPACITY` to
+     observed value automatically. The integration's `const.py`
+     `DEFAULT_FIELD_CAPACITY` becomes a fallback only.
+
+2. **Dryback episodes** (`root_zone.DrybackEpisode`)
+   - Wraps the existing `AdvancedDrybackDetector`.
+   - Persists each episode (`peak_vwc`, `valley_vwc`, `pct`, `duration_min`,
+     `slope`, `phase`, `ec_at_peak`, `ec_at_valley`, `vpd_avg`,
+     `light_dli_partial`) to SQLite for the analytics module.
+   - Emits `crop_steering_dryback_complete` events with the full payload.
+
+3. **Substrate analytics sensors** — new template/derived sensors (computed in
+   the AppDaemon module, published via `mqtt.publish` for dashboard use):
+   - `sensor.crop_steering_zone_{n}_dryback_velocity_pct_per_hr`
+   - `sensor.crop_steering_zone_{n}_substrate_porosity_estimate`
+   - `sensor.crop_steering_zone_{n}_ec_stack_index` (cumulative drift)
+
+4. **Multi-metric history dashboard** — `dashboards/rootsense_history.yaml`
+   with ApexCharts overlays for VWC + EC + shots + photoperiod marker.
+
+5. **Recorder includes** — extend the irrigation package
+   (`packages/irrigation/00_core.yaml`) with explicit `recorder.include` for
+   the new sensors so the new history dashboard works without extra setup.
+
+### Phase 2 — Adaptive Irrigation Intelligence (PR #3)
+
+1. **Cultivator intent** — new `number.crop_steering_steering_intent`
+   (range −100 … +100, step 5, default 0).
+   - −100 = "pure generative" (large dryback target, larger less-frequent shots,
+     higher EC ceiling).
+   - +100 = "pure vegetative" (small dryback target, more shots, lower EC).
+   - Runtime-editable via the existing GUI.
+
+2. **Profile interpolation** (`adaptive_irrigation.IntentResolver`)
+   - Loads two endpoint profiles per cultivar from `intelligent_crop_profiles.py`
+     and interpolates every parameter:
+     `value = lerp(profile_gen[k], profile_veg[k], (intent + 100) / 200)`
+   - Re-publishes derived parameters (P1 target VWC, P2 threshold, dryback
+     drop %, EC target, shot size) every time the intent slider moves.
+   - Existing `select.crop_steering_steering_mode` becomes a derived select
+     showing `Vegetative` / `Generative` / `Mixed (intent=+25)`.
+
+   **P0 dryback is fully operator-controlled.** No code path uses a hard-coded
+   number for "what % to dry back by". The two endpoints are read live every
+   tick from `number.crop_steering_veg_p0_dryback_drop_pct` and
+   `number.crop_steering_gen_p0_dryback_drop_pct`, and only fall back to
+   `DEFAULT_VEG_P0_DRYBACK_DROP_PCT` / `DEFAULT_GEN_P0_DRYBACK_DROP_PCT` from
+   `const.py` if the entities are unavailable. Both values are *drops* from
+   peak VWC — never absolute VWC targets. The interpolated current target is
+   exposed as `sensor.crop_steering_p0_dryback_drop_pct_current` and pushed
+   into the legacy `number.crop_steering_p0_dryback_drop_percent` entity that
+   the master app's P0-exit predicate already reads, so no other code change
+   is needed for the new semantic to take effect.
+
+3. **Shot planner** (`adaptive_irrigation.ShotPlanner`)
+   - On each P1/P2 shot decision, computes shot volume from:
+     - observed field capacity
+     - current VWC vs target
+     - dryback velocity (recovery shot vs maintenance shot)
+     - cultivator intent (bias toward dryback or rebound)
+   - Issues `crop_steering.custom_shot` rather than a hard-coded percentage.
+
+4. **Continuous optimisation loop** (`adaptive_irrigation.OptimisationLoop`)
+   - Reward function `r = -(|observed_dryback − target_dryback|) − 0.5 * |ec_runoff − ec_feed * target_ratio|`
+   - One-armed bandit (Thompson sampling, conjugate normal-gamma prior, all in
+     `numpy` — no scikit-learn needed for this part) tunes shot-size delta
+     and inter-shot interval per zone, persisting posterior in SQLite.
+   - Hard guardrails: no shot >2× field-capacity volume, no inter-shot interval
+     <`min_shot_spacing_sec` (default 90 s).
+
+5. **Phase-machine refactor** — `phase_state_machine.py` keeps its API but
+   its transition predicates now consult `OptimisationLoop` for "should we
+   move to P3" / "is P0 dryback complete" instead of fixed durations.
+
+### Phase 3 — Agronomic Intelligence (PR #4)
+
+1. **Transpiration model** (`agronomic.TranspirationModel`)
+   - Penman–Monteith style approximation:
+     `ET_h = (0.408 * Δ * (Rn) + γ * (900/(T+273)) * u * (es-ea)) / (Δ + γ * (1 + 0.34*u))`
+     where `Rn` is derived from PPFD or lux sensor, `es-ea` from VPD,
+     `u` defaults to `room_air_movement_m_s` number entity.
+   - Calibrates a per-zone gain factor against measured `ΔVWC * substrate_volume_L`
+     during P0 (no irrigation interferes there).
+   - Publishes `sensor.crop_steering_zone_{n}_transpiration_ml_per_hr`.
+
+2. **Climate–substrate interaction** (`agronomic.ClimateSubstrateModel`)
+   - Rolling Pearson correlation between VPD and dryback velocity per cultivar.
+   - Identifies "VPD ceiling" — the VPD above which substrate dryback
+     accelerates non-linearly — and exposes
+     `sensor.crop_steering_cultivar_{c}_vpd_ceiling_kpa`.
+
+3. **Whole-run analytics** (`agronomic.RunAnalytics`)
+   - Aggregates SQLite store nightly at `lights_off + 1h`.
+   - Emits `crop_steering_run_report` event with: shots/zone, total mL/zone,
+     mean dryback %, dryback variance, EC drift, anomalies, transpiration
+     totals.
+   - Dashboard card subscribes via `event` trigger.
+
+4. **Cultivar registry** — extend `intelligent_crop_profiles.py` with calibrated
+   defaults for Cannabis Athena / Hybrid / Indica / Sativa endpoint profiles
+   for the IntentResolver.
+
+### Phase 4 — Orchestration & Anomaly Detection (PR #5)
+
+1. **Coordinator** (`orchestration.Coordinator`)
+   - Replaces the decision loop currently inside
+     `master_crop_steering_app.py`. Master app shrinks to ~500 lines: it owns
+     hardware sequencing and event routing only.
+   - Subscribes to all `RootSenseBus` topics, arbitrates between modules.
+     E.g., if `anomaly.scanner` raises a `valve_stuck` event the coordinator
+     suppresses any pending shot to that zone.
+
+2. **On-demand custom shots** — new HA service
+   `crop_steering.custom_shot`:
+   ```yaml
+   target_zone: 1
+   intent: "rescue" | "rebalance_ec" | "test_emitter" | "free_text"
+   volume_ml: 250
+   target_runoff_pct: 15        # optional, planner will stop early if reached
+   tag: "operator_morning_check"  # logged for analytics
+   ```
+   The service writes a row into the analytics store, fires
+   `crop_steering_custom_shot`, and the orchestration coordinator schedules it
+   through normal safety gates.
+
+3. **Emergency irrigation guardrails**
+   - Existing emergency rescue at `VWC < 40` is preserved.
+   - Added: `ec_runoff > 1.5 * ec_feed` triggers a `flush_shot` (10 % FC volume)
+     with a hard cap of one flush per 4 h per zone.
+   - Added: `vwc_flat_for > 30 min during photoperiod` raises an anomaly,
+     does **not** auto-irrigate (likely sensor failure), notifies operator.
+
+4. **Anomaly scanner** (`anomaly.AnomalyScanner`, runs every 60 s)
+   - Per-zone rules:
+     - `emitter_blockage`: shot fired but ΔVWC over `shot_response_window_sec`
+       < 0.3% on >2 consecutive shots.
+     - `ec_drift_high`: 6-h rolling mean EC > 1.3× target.
+     - `vwc_flat_line`: stddev over last 30 min < 0.05% during photoperiod.
+     - `dryback_undetected`: 4 h since last detected peak during photoperiod.
+   - Peer-comparison rules (zones in same room with same cultivar):
+     - `peer_vwc_deviation`: zone VWC > 2σ from peer mean for 15 min.
+     - `peer_ec_deviation`: zone EC > 2σ from peer mean for 30 min.
+   - Each anomaly fires `crop_steering_anomaly` with payload
+     `{zone, code, severity, evidence, remediation}`, written to SQLite, and
+     surfaces on a `binary_sensor.crop_steering_anomaly_active`.
+
+5. **Incident reports** — `agronomic.RunAnalytics` correlates anomalies that
+   occurred during a run and adds them to the nightly report, generating a
+   markdown remediation block (e.g. "Zone 3 emitter blocked at 14:32 — recommended
+   actions: 1) inspect dripper line; 2) test emitter pressure; 3) re-run
+   `crop_steering.custom_shot zone=3 intent=test_emitter volume_ml=50`").
+
+### Phase 5 — Documentation, Migration, Release (PR #6)
+
+- `docs/upgrade/ROOTSENSE_v3_PLAN.md` (this file) → split into per-pillar
+  user docs in `docs/intelligence/`.
+- `MIGRATION.md` — step-by-step from v2.3.x to v3.0 (no data loss; intent
+  slider defaults to 0 = legacy "Vegetative" behaviour for first 7 days).
+- `CHANGELOG.md` — versioned entry per PR.
+- Update `manifest.json` and `const.py` `SOFTWARE_VERSION` to `3.0.0`.
+
+---
+
+## 4. Blueprint examples
+
+### 4.1 `blueprints/automation/crop_steering/rootsense_intent.yaml`
+
+A blueprint so growers can wire the cultivator intent slider to a remote, NFC
+tag, voice command, or schedule without writing YAML.
+
+```yaml
+blueprint:
+  name: RootSense — Cultivator Intent Setter
+  description: >
+    Set the global crop-steering intent (-100 = pure generative,
+    +100 = pure vegetative). Use a schedule helper, button, voice command,
+    or any trigger to bias the controller's behaviour without touching
+    individual thresholds.
+  domain: automation
+  input:
+    trigger_event:
+      name: Trigger
+      description: What should set the intent?
+      selector:
+        trigger:
+    target_intent:
+      name: Target intent
+      description: -100 (generative) … +100 (vegetative)
+      default: 0
+      selector:
+        number:
+          min: -100
+          max: 100
+          step: 5
+          mode: slider
+    notify_target:
+      name: Notification target (optional)
+      default: ""
+      selector:
+        text:
+
+trigger: !input trigger_event
+
+action:
+  - service: number.set_value
+    target:
+      entity_id: number.crop_steering_steering_intent
+    data:
+      value: !input target_intent
+  - if:
+      - condition: template
+        value_template: "{{ notify_target | length > 0 }}"
+    then:
+      - service: notify.send_message
+        target:
+          entity_id: !input notify_target
+        data:
+          message: >
+            Crop-steering intent set to {{ states('number.crop_steering_steering_intent') }}.
+```
+
+### 4.2 `blueprints/automation/crop_steering/rootsense_anomaly_handler.yaml`
+
+```yaml
+blueprint:
+  name: RootSense — Anomaly Handler
+  description: >
+    Listen for crop_steering_anomaly events and route them. Severities map
+    to your preferred notification target, and the remediation steps are
+    included verbatim in the message.
+  domain: automation
+  input:
+    severity_min:
+      name: Minimum severity
+      default: warning
+      selector:
+        select:
+          options: [info, warning, critical]
+    info_target:
+      name: Info notification target
+      default: ""
+      selector: { text: {} }
+    warning_target:
+      name: Warning notification target
+      default: ""
+      selector: { text: {} }
+    critical_target:
+      name: Critical notification target
+      default: ""
+      selector: { text: {} }
+
+trigger:
+  - platform: event
+    event_type: crop_steering_anomaly
+
+variables:
+  severity: "{{ trigger.event.data.severity }}"
+  zone: "{{ trigger.event.data.zone }}"
+  code: "{{ trigger.event.data.code }}"
+  remediation: "{{ trigger.event.data.remediation | default('See dashboard for details.') }}"
+  target: >
+    {% if severity == 'critical' %}{{ critical_target }}
+    {% elif severity == 'warning' %}{{ warning_target }}
+    {% else %}{{ info_target }}{% endif %}
+
+condition:
+  - condition: template
+    value_template: >
+      {% set order = {'info': 0, 'warning': 1, 'critical': 2} %}
+      {{ order[severity] >= order[severity_min] }}
+  - condition: template
+    value_template: "{{ target | length > 0 }}"
+
+action:
+  - service: notify.send_message
+    target:
+      entity_id: "{{ target }}"
+    data:
+      title: "🌱 RootSense — {{ severity | upper }}: Zone {{ zone }} {{ code }}"
+      message: |
+        {{ trigger.event.data.evidence }}
+
+        Recommended actions:
+        {{ remediation }}
+```
+
+---
+
+## 5. Testing & validation
+
+The existing `tests/` directory uses `pytest` with HA fixtures. The new
+modules are pure-Python and easy to unit-test in isolation.
+
+### Unit tests (PR-local)
+
+- `tests/intelligence/test_field_capacity_observer.py`
+  - Feed a synthetic shot → VWC-rise series, assert FC observation
+    converges to ground truth within 5 shots.
+- `tests/intelligence/test_intent_resolver.py`
+  - Sweep intent −100 → +100, assert all derived parameters monotonic.
+- `tests/intelligence/test_shot_planner.py`
+  - Property test: planner never requests volume > 2× FC, never <50 mL.
+- `tests/intelligence/test_optimisation_loop.py`
+  - Simulated environment: 100 P0/P1 cycles, assert reward improves
+    over time vs static baseline.
+- `tests/intelligence/test_anomaly_scanner.py`
+  - Inject blocked-emitter scenario (shots with ΔVWC ≈ 0), assert
+    `emitter_blockage` event fires within 3 shots.
+
+### Integration tests (HA + AppDaemon)
+
+- The repo already has the "Crop Steering Test Helpers" device with
+  `input_boolean` valves and `input_number` sensors. Extend with:
+  - `input_number.test_dripper_blockage` (0…1 fraction) — when nonzero,
+    the test sensor harness damps simulated VWC rise. Confirms
+    end-to-end anomaly path.
+  - `input_select.test_steering_intent_target` — automation flicks intent
+    every minute and asserts derived numbers update within one tick.
+
+### Field validation (pre-release)
+
+Three-tier rollout:
+
+1. **Shadow mode (week 1):** modules read sensors and write log events
+   only. No service calls. Operator compares logged decisions to the
+   live v2.3 controller.
+2. **Co-pilot mode (week 2):** intent slider active, but every shot is
+   gated on `input_boolean.crop_steering_rootsense_arm`. Operator
+   approves the first 100 shots manually; auto-arms once 95 % approval
+   rate is reached.
+3. **Full autonomy (week 3+):** orchestration module has full control;
+   master app is the hardware-only layer. Anomaly notifications go to
+   operator's preferred channel.
+
+### CI
+
+- `ruff check . && black --check . && yamllint -s .` (existing).
+- New: `pytest tests/intelligence/ -v --cov=appdaemon/apps/crop_steering/intelligence --cov-fail-under=80`.
+
+---
+
+## 6. Future roadmap (post-v3.0)
+
+- **v3.1 — Multi-room federation.** Treat each grow room as a
+  `RootSenseDomain`; share cultivar field-capacity observations between
+  rooms growing the same strain to bootstrap new transplants faster.
+- **v3.2 — Recipe library.** Export/import a full crop-steering recipe
+  (intent schedule + cultivar profile + EC ramp + photoperiod) as a
+  single YAML; pin to a strain in the cultivar registry.
+- **v3.3 — Local LLM advisor.** Optional integration with a locally
+  hosted model (Ollama, LM Studio) that ingests the nightly run report
+  and produces a plain-English summary + suggested intent adjustment for
+  the next 24 h. Off by default; no data leaves the LAN.
+- **v3.4 — Vision-based canopy module.** Optional Frigate integration:
+  a daily canopy-density estimate from a top-down camera feeds the
+  transpiration model's leaf-area-index term.
+- **v3.5 — Runoff conductivity controller.** Closed-loop on runoff EC
+  via a feed-EC dosing pump (Atlas Scientific or similar) — extends the
+  current EC monitoring into active control.
+
+---
+
+## 7. Risks & mitigations
+
+| Risk                                                   | Mitigation                                                                              |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| Adaptive loop misbehaves and drowns/dries plants       | Hard guardrails in `ShotPlanner`; co-pilot-mode rollout; unchanged emergency rescue     |
+| New SQLite store grows unbounded                       | Daily VACUUM; 90-day rolling retention by default; configurable                         |
+| Sensor outages confuse field-capacity observer         | Observer requires both VWC sensors (front+back) reporting & in-range; otherwise skip    |
+| Existing users on v2.3 are surprised by behaviour     | All new pillars opt-in; intent defaults to 0; `MIGRATION.md` walks through 7-day phase  |
+| AppDaemon container missing scikit-learn               | Used only in `OptimisationLoop`; module logs and degrades to fixed-step search if absent |
+
+---
+
+*End of plan. The accompanying scaffolds in
+`appdaemon/apps/crop_steering/intelligence/` are runnable but inert; they will
+be wired in during PRs #2–#5 above.*

--- a/docs/upgrade/ROOTSENSE_v3_PLAN.md
+++ b/docs/upgrade/ROOTSENSE_v3_PLAN.md
@@ -93,6 +93,17 @@ RootSense v3.0 turns the controller into an adaptive platform:
 The plan is broken into five phases. Each phase is independently mergeable, has
 its own test plan, and ships behind feature flags so existing users can opt in.
 
+### Status (live)
+
+| Phase | State | Landed |
+|---|---|---|
+| Phase 0 — Foundation | ✅ done | `bb97e5d` (this branch) |
+| Phase 1 — Root Zone Intelligence | 🟡 in progress | Substrate analytics sensors + dryback episode tracker + module-enable switches + recorder package shipped this commit. Multi-metric dashboard YAML still pending. |
+| Phase 2 — Adaptive Irrigation | ⬜ next | |
+| Phase 3 — Agronomic Intelligence | ⬜ planned | |
+| Phase 4 — Orchestration & Anomaly | ⬜ planned | |
+| Phase 5 — Docs / migration / release | ⬜ planned | |
+
 ### Phase 0 — Foundation (this commit)
 
 **Goal:** new directory layout, shared infrastructure, no behaviour change.

--- a/docs/upgrade/apps.example.yaml
+++ b/docs/upgrade/apps.example.yaml
@@ -1,0 +1,37 @@
+# Example AppDaemon apps.yaml additions for RootSense v3.0.
+# Copy the blocks you want into appdaemon/apps/apps.yaml.
+# Each block is independent; enable pillars one at a time.
+
+rootsense_root_zone:
+  module: crop_steering.intelligence.root_zone
+  class: RootZoneIntelligence
+  response_window_sec: 600
+  saturation_delta_pct: 0.5
+  fc_ewma_alpha: 0.25
+  fc_confidence_threshold: 0.8
+
+rootsense_adaptive:
+  module: crop_steering.intelligence.adaptive_irrigation
+  class: AdaptiveIrrigation
+
+rootsense_agronomic:
+  module: crop_steering.intelligence.agronomic
+  class: AgronomicIntelligence
+  air_temp_entity: sensor.grow_room_air_temperature
+  rh_entity: sensor.grow_room_humidity
+  ppfd_entity: sensor.grow_room_ppfd
+  room_air_movement_m_s: 0.3
+
+rootsense_orchestrator:
+  module: crop_steering.intelligence.orchestration
+  class: IrrigationOrchestrator
+  flush_cooldown_min: 240
+  emergency_vwc_pct: 40
+
+rootsense_anomaly:
+  module: crop_steering.intelligence.anomaly
+  class: AnomalyScanner
+  scan_interval_s: 60
+  peer_groups:
+    flower_room_a: [1, 2, 3]
+    flower_room_b: [4, 5, 6]

--- a/packages/rootsense/00_recorder.yaml
+++ b/packages/rootsense/00_recorder.yaml
@@ -1,0 +1,51 @@
+###############################################################################
+# RootSense GROW PACK — 00 RECORDER INCLUDES
+# /config/packages/rootsense/00_recorder.yaml
+#
+# PURPOSE : Make sure all RootSense-published sensors are kept in HA's
+#           recorder long-term, so dashboards (especially the multi-metric
+#           history view) have data to render.
+#
+# ENABLE  : Add the following to your configuration.yaml if you have not
+#           already enabled packages:
+#             homeassistant:
+#               packages: !include_dir_named packages
+#
+# NOTE    : This file uses an `entity_globs` include — Home Assistant 2024.6+
+#           is required. The patterns intentionally do not exclude any
+#           crop_steering entities so that dryback episodes, field capacity
+#           observations, and anomaly states all appear on the history graphs.
+###############################################################################
+
+recorder:
+  include:
+    entity_globs:
+      # RootSense pillar 1 sensors
+      - sensor.crop_steering_zone_*_field_capacity_observed
+      - sensor.crop_steering_zone_*_dryback_velocity_pct_per_hr
+      - sensor.crop_steering_zone_*_substrate_porosity_estimate_ml_per_pct
+      - sensor.crop_steering_zone_*_ec_stack_index
+      # RootSense pillar 2 sensors
+      - sensor.crop_steering_p0_dryback_drop_pct_current
+      # RootSense pillar 3 sensors
+      - sensor.crop_steering_zone_*_transpiration_ml_per_hr
+      - sensor.crop_steering_cultivar_*_vpd_ceiling_kpa
+      # RootSense pillar 4 sensors
+      - binary_sensor.crop_steering_anomaly_active
+      # Existing zone metrics that the multi-metric history dashboard overlays
+      - sensor.crop_steering_zone_*_avg_vwc
+      - sensor.crop_steering_zone_*_avg_ec
+      - sensor.crop_steering_zone_*_substrate_temperature
+      - sensor.crop_steering_zone_*_ec_runoff
+      - sensor.crop_steering_zone_*_ec_feed
+    entities:
+      - select.crop_steering_irrigation_phase
+      - number.crop_steering_steering_intent
+      - number.crop_steering_p0_dryback_drop_percent
+      - number.crop_steering_veg_p0_dryback_drop_pct
+      - number.crop_steering_gen_p0_dryback_drop_pct
+      - switch.crop_steering_intelligence_root_zone_enabled
+      - switch.crop_steering_intelligence_adaptive_enabled
+      - switch.crop_steering_intelligence_agronomic_enabled
+      - switch.crop_steering_intelligence_orchestrator_enabled
+      - switch.crop_steering_intelligence_anomaly_enabled

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+import types
+from enum import Enum
+
+homeassistant = types.ModuleType("homeassistant")
+homeassistant.__path__ = []
+
+config_entries = types.ModuleType("homeassistant.config_entries")
+const = types.ModuleType("homeassistant.const")
+core = types.ModuleType("homeassistant.core")
+exceptions = types.ModuleType("homeassistant.exceptions")
+helpers = types.ModuleType("homeassistant.helpers")
+entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+
+class ConfigEntry: ...
+class HomeAssistant: ...
+class ConfigEntryNotReady(Exception): ...
+class Platform(str, Enum):
+    SENSOR = "sensor"
+    SWITCH = "switch"
+    SELECT = "select"
+    NUMBER = "number"
+    BUTTON = "button"
+
+config_entries.ConfigEntry = ConfigEntry
+core.HomeAssistant = HomeAssistant
+exceptions.ConfigEntryNotReady = ConfigEntryNotReady
+const.Platform = Platform
+helpers.entity_registry = entity_registry
+
+sys.modules.setdefault("homeassistant", homeassistant)
+sys.modules.setdefault("homeassistant.config_entries", config_entries)
+sys.modules.setdefault("homeassistant.const", const)
+sys.modules.setdefault("homeassistant.core", core)
+sys.modules.setdefault("homeassistant.exceptions", exceptions)
+sys.modules.setdefault("homeassistant.helpers", helpers)
+sys.modules.setdefault("homeassistant.helpers.entity_registry", entity_registry)

--- a/tests/intelligence/__init__.py
+++ b/tests/intelligence/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for RootSense intelligence pillars."""

--- a/tests/intelligence/test_dryback_tracker.py
+++ b/tests/intelligence/test_dryback_tracker.py
@@ -1,0 +1,168 @@
+"""Unit tests for the local dryback episode tracker in root_zone.py.
+
+These tests do not need an AppDaemon runtime — they exercise the pure
+state-machine logic of `_step_dryback_tracker` on a `RootZoneIntelligence`
+instance whose AppDaemon hooks are stubbed out.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+# Stub AppDaemon hassapi before importing root_zone so the import path
+# resolves cleanly without a running AppDaemon.
+import types
+
+ad_module = types.ModuleType("appdaemon")
+ad_module.__path__ = []
+ad_plugins = types.ModuleType("appdaemon.plugins")
+ad_plugins.__path__ = []
+ad_hass = types.ModuleType("appdaemon.plugins.hass")
+ad_hass.__path__ = []
+ad_hassapi = types.ModuleType("appdaemon.plugins.hass.hassapi")
+
+
+class _Hass:
+    """Bare-minimum hass.Hass stand-in; the test patches all methods used."""
+
+    def __init__(self):  # noqa: D401
+        self.app_dir = "."
+        self.args = {}
+
+    # APIs touched by the modules under test — overridden in the fixture.
+    def get_state(self, *a, **kw): return None
+    def set_state(self, *a, **kw): pass
+    def listen_event(self, *a, **kw): pass
+    def listen_state(self, *a, **kw): pass
+    def run_every(self, *a, **kw): pass
+    def run_in(self, *a, **kw): pass
+    def run_daily(self, *a, **kw): pass
+    def fire_event(self, *a, **kw): pass
+    def call_service(self, *a, **kw): pass
+    def register_service(self, *a, **kw): pass
+    def log(self, *a, **kw): pass
+
+
+ad_hassapi.Hass = _Hass
+sys.modules["appdaemon"] = ad_module
+sys.modules["appdaemon.plugins"] = ad_plugins
+sys.modules["appdaemon.plugins.hass"] = ad_hass
+sys.modules["appdaemon.plugins.hass.hassapi"] = ad_hassapi
+
+# Make the appdaemon/apps directory importable.
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "appdaemon" / "apps"))
+
+from crop_steering.intelligence.root_zone import (  # noqa: E402
+    DEFAULT_DRYBACK_MIN_DROP_PCT,
+    DEFAULT_DRYBACK_MIN_DURATION_MIN,
+    RootZoneIntelligence,
+)
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Build a RootZoneIntelligence with all AppDaemon side effects neutered."""
+    a = RootZoneIntelligence.__new__(RootZoneIntelligence)
+    a.app_dir = str(tmp_path)
+    a.args = {}
+    # Manually reproduce what initialize() sets up, skipping AppDaemon I/O.
+    from collections import defaultdict, deque
+    from crop_steering.intelligence.bus import RootSenseBus
+    from crop_steering.intelligence.store import RootSenseStore
+    from crop_steering.intelligence.root_zone import DrybackTracker, FieldCapacityState
+
+    a.bus = RootSenseBus.instance()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    a.store = RootSenseStore(state_dir / "rootsense.db")
+    a.dryback_min_drop_pct = DEFAULT_DRYBACK_MIN_DROP_PCT
+    a.dryback_min_duration_min = DEFAULT_DRYBACK_MIN_DURATION_MIN
+    a._dryback = defaultdict(DrybackTracker)
+    a._fc = defaultdict(FieldCapacityState)
+    a._vwc_buf = defaultdict(lambda: deque(maxlen=1440))
+    a._ec_buf = defaultdict(lambda: deque(maxlen=1440))
+    a._pending = {}
+
+    # No-op the HA-side emit
+    a.fire_event = lambda *a_, **k_: None
+    a.set_state = lambda *a_, **k_: None
+    a.log = lambda *a_, **k_: None
+    a.get_state = lambda *a_, **k_: "P0"
+    return a
+
+
+def _drive(app, zone: int, samples: list[tuple[int, float]]):
+    """Feed (minutes_offset, vwc) samples into the tracker."""
+    base = datetime(2026, 4, 26, 6, 0, 0)
+    for minute, vwc in samples:
+        ts = base + timedelta(minutes=minute)
+        app._step_dryback_tracker(zone, ts, vwc, ec=2.5)
+
+
+def test_dryback_emits_after_full_cycle(app):
+    """Peak → 20%-drop valley → rebound > min_drop emits one episode."""
+    captured = []
+
+    def grab(name, **payload):  # fire_event signature
+        if name == "crop_steering_dryback_complete":
+            captured.append(payload)
+
+    app.fire_event = grab
+
+    # Sample series: rise to 70%, drop to 50% over 60 min, then rebound to 53%.
+    series = (
+        [(0, 60.0), (5, 65.0), (10, 70.0)]                      # peak
+        + [(15, 68.0), (30, 60.0), (60, 50.0), (75, 50.0)]      # valley
+        + [(90, 53.0)]                                          # rebound > min_drop_pct
+    )
+    _drive(app, zone=1, samples=series)
+
+    assert len(captured) == 1
+    ep = captured[0]
+    assert ep["zone"] == 1
+    assert ep["peak_vwc"] == 70.0
+    assert ep["valley_vwc"] == 50.0
+    assert ep["pct"] == 20.0
+    assert ep["duration_min"] >= DEFAULT_DRYBACK_MIN_DURATION_MIN
+
+
+def test_short_dryback_is_ignored(app):
+    """Drop that's too short in duration must not emit."""
+    captured = []
+    app.fire_event = lambda name, **payload: captured.append(payload)
+
+    _drive(app, zone=2, samples=[
+        (0, 70.0), (5, 68.0), (10, 65.0), (12, 67.0),  # rebound at 12 min
+    ])
+    assert captured == []
+
+
+def test_micro_fluctuation_is_ignored(app):
+    """Tiny VWC wobbles below dryback_min_drop_pct must not emit episodes."""
+    captured = []
+    app.fire_event = lambda name, **payload: captured.append(payload)
+
+    _drive(app, zone=3, samples=[
+        (0, 70.0), (10, 69.7), (20, 70.0), (30, 69.9), (60, 70.1),
+    ])
+    assert captured == []
+
+
+def test_new_higher_peak_resets_tracker(app):
+    """If VWC rises strictly above the current peak, we should be tracking
+    the new peak rather than emitting a fake episode for the wobble."""
+    captured = []
+    app.fire_event = lambda name, **payload: captured.append(payload)
+
+    _drive(app, zone=4, samples=[
+        (0, 60.0), (10, 65.0), (20, 70.0),       # peak at 70
+        (30, 69.5),                               # tiny dip
+        (40, 72.0),                               # new higher peak
+    ])
+    assert captured == []
+    tracker = app._dryback[4]
+    assert tracker.peak_vwc == 72.0

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,6 +1,6 @@
 """Unit tests for Crop Steering System calculations."""
 import pytest
-from custom_components.crop_steering.sensor import ShotCalculator
+from custom_components.crop_steering.calculations import ShotCalculator
 from custom_components.crop_steering.const import (
     SECONDS_PER_HOUR,
     PERCENTAGE_TO_RATIO,
@@ -67,13 +67,13 @@ class TestShotCalculator:
     def test_large_pot_volume(self):
         """Test calculation with large pot."""
         # 50L pot, 5 L/hr flow, 5% shot size
-        # Expected: (50 * 0.05) / 5 * 3600 = 900 seconds
+        # Expected: (50 * 0.05) / 5 * 3600 = 1800 seconds
         result = ShotCalculator.calculate_shot_duration(
             dripper_flow=5.0,
             substrate_vol=50.0,
             shot_size=5.0
         )
-        assert result == 900.0
+        assert result == 1800.0
 
     def test_zero_flow_rate(self):
         """Test calculation with zero flow rate returns 0."""
@@ -301,9 +301,9 @@ class TestEdgeCases:
             substrate_vol=11.3,
             shot_size=4.8
         )
-        # Expected: (11.3 * 0.048) / 2.7 * 3600 = 722.666... rounds to 722.7
+        # Expected: (11.3 * 0.048) / 2.7 * 3600 = 723.2
         assert isinstance(result, float)
-        assert result == 722.7
+        assert result == 723.2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Evolves the rule-based 4-phase controller into an adaptive crop-steering platform with four opt-in intelligence pillars: Root Zone, Adaptive Irrigation, Agronomic, Orchestration — plus a cross-cutting anomaly scanner.

## What's in this PR

### Phase 0 — Foundation (commit `bb97e5d`)
- New package `appdaemon/apps/crop_steering/intelligence/` with five pillar apps + shared infrastructure (`bus.py` in-process pub/sub, `store.py` SQLite analytics store at `rootsense.db`).
- `docs/upgrade/ROOTSENSE_v3_PLAN.md` — full design, 5-phase roadmap, feature mapping, testing plan, future roadmap.
- `docs/upgrade/apps.example.yaml` — example AppDaemon `apps.yaml` block to opt in.
- **P0 dryback semantic clarified**: it is now unambiguously *"% drop from peak VWC"* (dries-back-by, not dries-back-to). Two new operator-facing sliders the IntentResolver reads live every tick:
  - `number.crop_steering_veg_p0_dryback_drop_pct` (range 2–40, default 12)
  - `number.crop_steering_gen_p0_dryback_drop_pct` (range 2–50, default 22)
  Defaults follow Athena cannabis guidance. Legacy `..._dryback_target` entities kept as aliases with corrected defaults. No hard-coded value anywhere in the new code path.

### Codex follow-up (commits `2b474e4`, `0b86d24`)
- `custom_components/crop_steering/calculations.py` — `ShotCalculator` extracted as pure helper for tests.
- `tests/conftest.py` — pytest fixtures stubbing the HA module surface.
- `docs/upgrade/GAP_ANALYSIS_2026-05.md` — module gap snapshot + prioritised To-Do.

### Phase 1 — Root Zone Intelligence wiring (commit `8da1c6d`)
- Per-zone rolling VWC + EC buffers sampled every 60 s.
- Local `DrybackTracker` state machine detects peak/valley pairs, persists each episode to `rootsense.db`, and emits `crop_steering_dryback_complete`.
- Three derived sensors per zone, previously stubs, now live:
  - `sensor.crop_steering_zone_{n}_dryback_velocity_pct_per_hr`
  - `sensor.crop_steering_zone_{n}_substrate_porosity_estimate_ml_per_pct`
  - `sensor.crop_steering_zone_{n}_ec_stack_index`
- New shared base `IntelligenceApp` provides module-enable gating + helpers; all 5 pillars inherit it.
- Five module-enable switches in the integration (default OFF) so each pillar is independently toggleable from the HA UI.
- `packages/rootsense/00_recorder.yaml` keeps the new sensors in HA's history.
- `docs/upgrade/RECONCILIATION.md` maps codex's gap-analysis P1/P2 items onto RootSense plan phases.
- `tests/intelligence/test_dryback_tracker.py` covers the state machine (4 cases, all green).

## Backward compatibility

- All new modules are opt-in; existing installs are unaffected on first upgrade.
- Modules are not added to `apps.yaml` automatically — see `docs/upgrade/apps.example.yaml` to opt in.
- Module-enable switches default OFF.
- Legacy entities and the existing P0 exit predicate continue to work unchanged.

## Test plan

- [x] Unit tests for the dryback episode tracker pass: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/intelligence/ -v` → 4 passed.
- [x] All intelligence modules compile cleanly (`python -m py_compile`).
- [ ] Manual: enable `switch.crop_steering_intelligence_root_zone_enabled` on a test HA, observe new sensors populate after one tick (60 s).
- [ ] Manual: trigger a `crop_steering_irrigation_shot` event and confirm `field_capacity_observed` updates after `response_window_sec`.
- [ ] Manual: drive a synthetic dryback (peak → valley → rebound > 1 % over > 15 min) and confirm `crop_steering_dryback_complete` fires.

## Roadmap (per `ROOTSENSE_v3_PLAN.md`)

- ✅ Phase 0 — foundation
- 🟡 Phase 1 — Root Zone Intelligence (this PR; multi-metric history dashboard YAML still pending)
- ⬜ Phase 2 — Adaptive Irrigation goes live (cultivator-intent slider, OptimisationLoop in shadow mode)
- ⬜ Phase 3 — Agronomic Intelligence (transpiration, VPD ceiling, climate-substrate validation)
- ⬜ Phase 4 — Orchestration takes hardware control; anomaly incident-report generator
- ⬜ Phase 5 — Blueprints, dashboards, MIGRATION.md, version bump to 3.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)