### PR TITLE
fix(addon): pH gate is skipped whenever the feed-EC probe is dead but in grace

### DIFF
--- a/addons/f2_control/f2_control/controller.py
+++ b/addons/f2_control/f2_control/controller.py
@@ -887,7 +887,7 @@ class Controller:
             hi = self._num(f"number.crop_steering_{room.prefix}irrigation_ec_max", 0)
             if lo > 0 or hi > 0:
                 if feed is None:
-                    if feed_grace_ok(
+                    if not feed_grace_ok(
                         datetime.now().timestamp(),
                         (
                             room._feed_last_good_time.timestamp()
@@ -896,9 +896,11 @@ class Controller:
                         ),
                         self.feed_grace_min,
                     ):
-                        return None
-                    return f"source-water EC dead >{self.feed_grace_min:.0f}min — holding (fail-closed)"
-                if (lo > 0 and feed < lo) or (hi > 0 and feed > hi):
+                        return f"source-water EC dead >{self.feed_grace_min:.0f}min — holding (fail-closed)"
+                    # Inside the grace window we skip the EC band check only — fall through
+                    # so the pH gate below still runs. Returning None here would report the
+                    # zone as unblocked and silently bypass pH entirely.
+                elif (lo > 0 and feed < lo) or (hi > 0 and feed > hi):
                     return f"source-water EC {feed:.1f} out of [{lo:g},{hi:g}]"
         # pH half of the source-water gate — bad-pH feed locks out nutrients / burns roots, so
         # gate it too, but only when a feed-pH sensor is configured.

--- a/addons/f2_control/tests/test_controller.py
+++ b/addons/f2_control/tests/test_controller.py
@@ -169,6 +169,47 @@ def test_hold_entities_are_configurable_and_f2_ids_no_longer_hardcoded():
     assert block and "external hold" in block and "my_dose" in block
 
 
+def test_ph_gate_still_runs_while_feed_ec_is_dead_but_in_grace():
+    """A dead feed-EC probe inside its grace window must not bypass the pH gate.
+
+    The EC half used to `return None` on the grace path, which reports the zone as
+    unblocked and skips every check below it — including pH. Bad-pH feed then irrigates.
+    """
+    c, fake = _build(
+        {
+            "num_zones": 1,
+            "feed_ec_sensor": "sensor.feed_ec",
+            "feed_ph_sensor": "sensor.feed_ph",
+            "hardware": {"pump": "switch.p", "mainline": "switch.m",
+                         "valves": {"1": "switch.v1"}},
+        },
+        states={
+            "sensor.crop_steering_vwc_zone_1": ("50", {}),
+            "input_boolean.f2_control_enabled": ("on", {}),
+            "switch.crop_steering_system_enabled": ("on", {}),
+            "switch.crop_steering_auto_irrigation_enabled": ("on", {}),
+            "switch.crop_steering_zone_1_enabled": ("on", {}),
+            "number.crop_steering_irrigation_ec_min": ("1.0", {}),
+            "number.crop_steering_irrigation_ec_max": ("3.5", {}),
+            "number.crop_steering_irrigation_ph_min": ("5.8", {}),
+            "number.crop_steering_irrigation_ph_max": ("6.2", {}),
+            "sensor.feed_ec": ("2.0", {}),      # in band -> banks a last-known-good
+            "sensor.feed_ph": ("6.0", {}),      # in band
+        },
+    )
+    room = c.rooms[0]
+    assert c._blocked(room, 1) is None  # everything healthy and in band
+
+    # EC probe dies, but we are still inside the grace window, so EC alone must not block.
+    fake.set_state("sensor.feed_ec", "unavailable")
+    assert c._blocked(room, 1) is None
+
+    # pH now goes out of band. The dead-but-in-grace EC probe must NOT mask it.
+    fake.set_state("sensor.feed_ph", "4.9")
+    block = c._blocked(room, 1)
+    assert block and "pH" in block, f"pH gate was skipped: {block!r}"
+
+
 def test_notify_service_empty_sends_no_mobile_push():
     c, fake = _build(
         {"num_zones": 1, "hardware": {"pump": "switch.p", "mainline": "switch.m",


### PR DESCRIPTION
## The bug

`_blocked()` runs the source-water **EC** band check before the **pH** band check. When the feed-EC probe is unreadable but still inside its last-known-good grace window, the EC half did this:

```python
if feed is None:
    if feed_grace_ok(...):
        return None          # <-- "EC alone does not block"
    return f"source-water EC dead >{self.feed_grace_min:.0f}min — holding (fail-closed)"
```

`None` is also the function's *"nothing blocks this zone"* return value. So that early return reported the zone as clear and **skipped every gate below it — the whole pH block included.**

Net effect: a dead feed-EC probe silently disabled pH protection for the entire grace window (default 30 min, and it re-arms on every successful read), and irrigation went ahead on out-of-band feed. Bad-pH feed locks out nutrients and burns roots, which is exactly what that gate exists to prevent.

## The fix

Invert the grace check so only the *expired* case returns a block, and make the EC band check an `elif` so it is never evaluated against `None`. Execution then falls through to the pH gate as intended.

```python
if feed is None:
    if not feed_grace_ok(...):
        return f"source-water EC dead >{self.feed_grace_min:.0f}min — holding (fail-closed)"
    # Inside the grace window we skip the EC band check only — fall through
    # so the pH gate below still runs.
elif (lo > 0 and feed < lo) or (hi > 0 and feed > hi):
    return f"source-water EC {feed:.1f} out of [{lo:g},{hi:g}]"
```

Behaviour is otherwise unchanged: an expired grace window still fails closed, an in-band feed still passes, and an out-of-band feed still blocks with the same message.

## Test

Adds `test_ph_gate_still_runs_while_feed_ec_is_dead_but_in_grace`, which banks a good EC reading, kills the probe, then pushes pH out of band and asserts the zone is blocked for pH.

On the previous code it fails with:

```
AssertionError: pH gate was skipped: None
```

Full add-on suite: 14 passed.

## Note on the pH block

The pH half has the same `return None` on its own grace path (`controller.py:920`). It is currently benign because nothing follows it, but it will become the same bug the moment another gate is appended after pH. Left alone here to keep this diff to the actual defect — worth a follow-up.
